### PR TITLE
Add Reified set support

### DIFF
--- a/src/MiniZinc.jl
+++ b/src/MiniZinc.jl
@@ -78,7 +78,7 @@ MOI.Utilities.@model(
 function MOI.supports_constraint(
     ::Model{T},
     ::Type{MOI.VectorAffineFunction{T}},
-    ::MOI.AbstractVectorSet,
+    ::Type{<:MOI.AbstractVectorSet},
 ) where {T}
     return false
 end

--- a/src/MiniZinc.jl
+++ b/src/MiniZinc.jl
@@ -29,6 +29,7 @@ Base.copy(s::Reified) = Reified(copy(s.set))
 const ReifiedLessThan{T} = Reified{MOI.LessThan{T}}
 const ReifiedGreaterThan{T} = Reified{MOI.GreaterThan{T}}
 const ReifiedEqualTo{T} = Reified{MOI.EqualTo{T}}
+const ReifiedBinPacking{T} = Reified{MOI.BinPacking{T}}
 
 MOI.Utilities.@model(
     Model,
@@ -52,6 +53,7 @@ MOI.Utilities.@model(
     (
         MOI.BinPacking,
         MOI.Table,
+        ReifiedBinPacking,
         ReifiedLessThan,
         ReifiedGreaterThan,
         ReifiedEqualTo,

--- a/src/MiniZinc.jl
+++ b/src/MiniZinc.jl
@@ -19,6 +19,12 @@ end
 import MathOptInterface
 const MOI = MathOptInterface
 
+"""
+    Reified(set::MOI.AbstractSet)
+
+The constraint ``[z; f(x)] \\in Reified(S)`` ensures that ``f(x) \\in S`` if and
+only if ``z == 1``, where ``z \\in \\{0, 1\\}``.
+"""
 struct Reified{S<:MOI.AbstractSet} <: MOI.AbstractVectorSet
     set::S
 end
@@ -46,10 +52,13 @@ MOI.Utilities.@model(
         MOI.Cumulative,
         MOI.Path,
         Reified{MOI.AllDifferent},
+        # Reified{MOI.Circuit}, Unsupported by MiniZinc
         Reified{MOI.CountAtLeast},
         Reified{MOI.CountBelongs},
         Reified{MOI.CountDistinct},
         Reified{MOI.CountGreaterThan},
+        Reified{MOI.Cumulative},
+        # Reified{MOI.Path}, Unsupported by MiniZinc
     ),
     (
         MOI.BinPacking,

--- a/src/MiniZinc.jl
+++ b/src/MiniZinc.jl
@@ -30,6 +30,7 @@ const ReifiedLessThan{T} = Reified{MOI.LessThan{T}}
 const ReifiedGreaterThan{T} = Reified{MOI.GreaterThan{T}}
 const ReifiedEqualTo{T} = Reified{MOI.EqualTo{T}}
 const ReifiedBinPacking{T} = Reified{MOI.BinPacking{T}}
+const ReifiedTable{T} = Reified{MOI.Table{T}}
 
 MOI.Utilities.@model(
     Model,
@@ -54,6 +55,7 @@ MOI.Utilities.@model(
         MOI.BinPacking,
         MOI.Table,
         ReifiedBinPacking,
+        ReifiedTable,
         ReifiedLessThan,
         ReifiedGreaterThan,
         ReifiedEqualTo,

--- a/src/write.jl
+++ b/src/write.jl
@@ -149,7 +149,14 @@ function _write_constraint(
     variables,
     F::Type{MOI.VectorOfVariables},
     S::Type{Reified{S2}},
-) where {S2<:Union{MOI.AllDifferent,MOI.CountDistinct,MOI.CountGreaterThan}}
+) where {
+    S2<:Union{
+        MOI.AllDifferent,
+        MOI.CountDistinct,
+        MOI.CountGreaterThan,
+        MOI.Cumulative,
+    },
+}
     for ci in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         f = MOI.get(model, MOI.ConstraintFunction(), ci)
         s = MOI.get(model, MOI.ConstraintSet(), ci)
@@ -431,7 +438,7 @@ function _write_predicates(io, model)
             println(io, "include \"alldifferent.mzn\";")
         elseif S <: MOI.BinPacking || S <: Reified{<:MOI.BinPacking}
             println(io, "include \"bin_packing.mzn\";")
-        elseif S == MOI.Circuit
+        elseif S == MOI.Circuit  # Reified unsupported by MiniZinc
             println(io, "include \"circuit.mzn\";")
         elseif S == MOI.CountAtLeast || S == Reified{MOI.CountAtLeast}
             println(io, "include \"at_least.mzn\";")
@@ -441,9 +448,9 @@ function _write_predicates(io, model)
             println(io, "include \"nvalue.mzn\";")
         elseif S == MOI.CountGreaterThan || S == Reified{MOI.CountGreaterThan}
             println(io, "include \"count_gt.mzn\";")
-        elseif S == MOI.Cumulative
+        elseif S == MOI.Cumulative || S == Reified{MOI.Cumulative}
             println(io, "include \"cumulative.mzn\";")
-        elseif S == MOI.Path
+        elseif S == MOI.Path  # Reified unsupported by MiniZinc
             println(io, "include \"path.mzn\";")
         elseif S <: MOI.Table || S <: Reified{<:MOI.Table}
             println(io, "include \"table.mzn\";")

--- a/src/write.jl
+++ b/src/write.jl
@@ -303,6 +303,24 @@ function _write_constraint(
     model,
     variables,
     F::Type{MOI.VectorOfVariables},
+    S::Type{<:Reified{<:MOI.BinPacking}},
+)
+    for ci in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+        f = MOI.get(model, MOI.ConstraintFunction(), ci)
+        s = MOI.get(model, MOI.ConstraintSet(), ci).set
+        b = _to_string(variables, f.variables[1])
+        x = _to_string(variables, f.variables[2:end])
+        print(io, "constraint $b <-> bin_packing(", s.capacity, ", ", x, ", ")
+        println(io, s.weights, ");")
+    end
+    return
+end
+
+function _write_constraint(
+    io::IO,
+    model,
+    variables,
+    F::Type{MOI.VectorOfVariables},
     S::Type{MOI.Path},
 )
     for ci in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
@@ -390,7 +408,7 @@ function _write_predicates(io, model)
     for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
         if S == MOI.AllDifferent || S == Reified{MOI.AllDifferent}
             println(io, "include \"alldifferent.mzn\";")
-        elseif S <: MOI.BinPacking
+        elseif S <: MOI.BinPacking  || S <: Reified{<:MOI.BinPacking}
             println(io, "include \"bin_packing.mzn\";")
         elseif S == MOI.Circuit
             println(io, "include \"circuit.mzn\";")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -823,6 +823,22 @@ function test_write_table_reified()
     return
 end
 
+function test_model_unsupported_vectoraffine_constraint()
+    model = MiniZinc.Model{Int}()
+    x = MOI.add_variables(model, 2)
+    f = MOI.Utilities.operate(vcat, Int, x[1], 2 * x[2])
+    @test MOI.supports_constraint(model, typeof(f), MOI.AllDifferent) == false
+    set = MiniZinc.Reified(MOI.GreaterThan(1))
+    @test MOI.supports_constraint(model, typeof(f), typeof(set)) == true
+    return
+end
+
+function test_reified_dimension()
+    @test MOI.dimension(MiniZinc.Reified(MOI.GreaterThan(1))) == 2
+    @test MOI.dimension(MiniZinc.Reified(MOI.AllDifferent(2))) == 3
+    return
+end
+
 function test_write_circuit()
     model = MiniZinc.Model{Int}()
     x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]


### PR DESCRIPTION
Part of https://github.com/jump-dev/MathOptInterface.jl/issues/1805#issuecomment-1132254501. 

Adding to MiniZinc.jl first to work out the kinks before we decide to add to MOI. I think that adding the Reified set with minimal infrastructure might be the way to go. It's a pretty solid/standard set and we already have `Indicator`, but it'd need a lot of other stuff before it was useful to non-constraint programming solvers.

MiniZinc doesn't support reified constraints for complicated sets like Table, Path, Cumulative, etc. It's been trial and error to see which are supported and which aren't.

 - [x] AllDifferent
 - [x] BinPacking
 - [x] <s>Circuit</s> `MiniZinc: evaluation error: Abort: Reified circuit/1 is not supported.`
 - [x] CountAtLeast
 - [x] CountBelongs
 - [x] CountDistinct
 - [x] CountGreaterThan
 - [x] Cumulative
 - [x] <s>Path</s> `MiniZinc: evaluation error: Abort: Reified path constraint is not supported`
 - [x] Table
 - [x] LessThan
 - [x] GreaterThan
 - [x] EqualTo