### PR TITLE
Support nonlinear constraints with Boolean operators

### DIFF
--- a/src/MiniZinc.jl
+++ b/src/MiniZinc.jl
@@ -71,6 +71,13 @@ function MOI.supports_constraint(
     return true
 end
 
+MOI.supports(::Model, ::MOI.NLPBlock) = true
+
+function MOI.set(model::Model, ::MOI.NLPBlock, data::MOI.NLPBlockData)
+    model.ext[:nlp_block] = data
+    return
+end
+
 include("write.jl")
 include("optimize.jl")
 

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -83,10 +83,13 @@ end
 
 # The MOI interface
 
+MOI.get(model::Optimizer, ::MOI.SolverName) = "MiniZinc"
+
 MOI.is_empty(model::Optimizer) = MOI.is_empty(model.inner)
 
 function MOI.empty!(model::Optimizer)
     MOI.empty!(model.inner)
+    empty!(model.inner.ext)
     model.has_solution = false
     empty!(model.primal_solution)
     return

--- a/src/write.jl
+++ b/src/write.jl
@@ -494,7 +494,14 @@ function _write_logical_expression(io, model, variables, expr)
 end
 
 function _write_call_expression(io, model, variables, expr)
-    ops = Dict(:- => "-", :+ => "+")
+    ops = Dict(
+        :- => "-",
+        :+ => "+",
+        :(<) => "<",
+        :(>) => ">",
+        :(<=) => "<=",
+        :(>=) => ">=",
+    )
     op = get(ops, expr.args[1], nothing)
     @assert op !== nothing
     print(io, "(")
@@ -528,11 +535,10 @@ function _write_expression(io, model, variables, x::MOI.VariableIndex)
 end
 
 function _write_expression(io, model, variables, x::Real)
-    if isone(x)
-        print(io, "1")
+    if isinteger(x)
+        print(io, round(Int, x))
     else
-        @assert iszero(x)
-        print(io, "0")
+        print(io, x)
     end
     return
 end

--- a/src/write.jl
+++ b/src/write.jl
@@ -460,6 +460,83 @@ function _write_predicates(io, model)
     return
 end
 
+function _write_constraint(io, model, variables, expr::Expr)
+    print(io, "constraint ")
+    if Meta.isexpr(expr, :call, 3)
+        @assert expr.args[1] in (:(<=), :(>=), :(<), :(>), :(==))
+        _write_expression(io, model, variables, expr.args[2])
+        rhs = expr.args[3]
+        if isone(rhs)
+            println(io, " $(expr.args[1]) true;")
+        else
+            @assert iszero(rhs)
+            println(io, " $(expr.args[1]) false;")
+        end
+    else
+        @assert Meta.isexpr(expr, :comparison, 5)
+        error("Two sided not supported")
+    end
+    return
+end
+
+function _write_logical_expression(io, model, variables, expr)
+    ops = Dict(:|| => "\\/", :&& => "/\\")
+    op = get(ops, expr.head, nothing)
+    @assert op !== nothing
+    print(io, "(")
+    _write_expression(io, model, variables, expr.args[1])
+    for i in 2:length(expr.args)
+        print(io, " ", op, " ")
+        _write_expression(io, model, variables, expr.args[i])
+    end
+    print(io, ")")
+    return
+end
+
+function _write_call_expression(io, model, variables, expr)
+    ops = Dict(:- => "-", :+ => "+")
+    op = get(ops, expr.args[1], nothing)
+    @assert op !== nothing
+    print(io, "(")
+    _write_expression(io, model, variables, expr.args[2])
+    for i in 3:length(expr.args)
+        print(io, " ", op, " ")
+        _write_expression(io, model, variables, expr.args[i])
+    end
+    print(io, ")")
+    return
+end
+
+function _write_expression(io, model, variables, expr::Expr)
+    if Meta.isexpr(expr, :ref)
+        @assert expr.args[1] == :x
+        _write_expression(io, model, variables, expr.args[2])
+        return
+    end
+    if Meta.isexpr(expr, :||) || Meta.isexpr(expr, :&&)
+        _write_logical_expression(io, model, variables, expr)
+    else
+        @assert Meta.isexpr(expr, :call)
+        _write_call_expression(io, model, variables, expr)
+    end
+    return
+end
+
+function _write_expression(io, model, variables, x::MOI.VariableIndex)
+    print(io, _to_string(variables, x))
+    return
+end
+
+function _write_expression(io, model, variables, x::Real)
+    if isone(x)
+        print(io, "1")
+    else
+        @assert iszero(x)
+        print(io, "0")
+    end
+    return
+end
+
 function Base.write(io::IO, model::Model{T}) where {T}
     MOI.FileFormats.create_unique_variable_names(
         model,
@@ -477,6 +554,14 @@ function Base.write(io::IO, model::Model{T}) where {T}
             continue
         end
         _write_constraint(io, model, variables, F, S)
+    end
+    nlp_block = get(model.ext, :nlp_block, nothing)
+    if nlp_block !== nothing
+        MOI.initialize(nlp_block.evaluator, [:ExprGraph])
+        for i in 1:length(nlp_block.constraint_bounds)
+            expr = MOI.constraint_expr(nlp_block.evaluator, i)
+            _write_constraint(io, model, variables, expr)
+        end
     end
     sense = MOI.get(model, MOI.ObjectiveSense())
     if sense == MOI.FEASIBILITY_SENSE

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1047,6 +1047,32 @@ function test_model_filename()
     return
 end
 
+function test_model_nlp_boolean()
+    model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Int}())
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.ZeroOne())
+    nlp = MOI.Nonlinear.Model()
+    a, b = x
+    MOI.Nonlinear.add_constraint(nlp, :(($a || $b) - 1.0), MOI.EqualTo(0.0))
+    MOI.Nonlinear.add_constraint(nlp, :(($a && $b) - 0.0), MOI.EqualTo(0.0))
+    backend = MOI.Nonlinear.ExprGraphOnly()
+    evaluator = MOI.Nonlinear.Evaluator(nlp, backend, x)
+    MOI.set(model, MOI.NLPBlock(), MOI.NLPBlockData(evaluator))
+    solver = MiniZinc.Optimizer{Int}(MiniZinc.Chuffed())
+    MOI.set(solver, MOI.RawOptimizerAttribute("model_filename"), "test.mzn")
+    index_map, _ = MOI.optimize!(solver, model)
+    println(read("test.mzn", String))
+    @test MOI.get(solver, MOI.TerminationStatus()) === MOI.OPTIMAL
+    @test MOI.get(solver, MOI.ResultCount()) >= 1
+    y = [index_map[v] for v in x]
+    sol = round.(Bool, MOI.get(solver, MOI.VariablePrimal(), y))
+    @test (sol[1] || sol[2]) == true
+    @test (sol[1] && sol[2]) == false
+    @test read("test.mzn", String) == "var bool: x1;\nvar bool: x2;\nconstraint ((x1 \\/ x2) - 1) == false;\nconstraint ((x1 /\\ x2) - 0) == false;\nsolve satisfy;\n"
+    rm("test.mzn")
+    return
+end
+
 end
 
 TestMiniZinc.runtests()


### PR DESCRIPTION
x-ref: https://github.com/jump-dev/JuMP.jl/issues/2227#issuecomment-1404491375

The demo is
```julia
julia> using JuMP

julia> import MiniZinc

julia> model = Model(() -> MiniZinc.Optimizer{Int}(MiniZinc.Chuffed()))
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: MiniZinc

julia> set_optimizer_attribute(model, "model_filename", "test.mzn")

julia> @variable(model, x, Bin)
x

julia> @variable(model, y, Bin)
y

julia> @constraint(model, [x, y] in MOI.AllDifferent(2))
[x, y] ∈ MathOptInterface.AllDifferent(2)

julia> @NLconstraint(model, (x || y) == true)
(x || y) - 1.0 = 0

julia> @NLconstraint(model, (x && y) == false)
(x && y) - 0.0 = 0

julia> optimize!(model)
Warning: included file "count.mzn" overrides a global constraint file from the standard library. This is deprecated. For a solver-specific redefinition of a global constraint, override "fzn_<global>.mzn" instead.

Warning: included file "global_cardinality_low_up.mzn" overrides a global constraint file from the standard library. This is deprecated. For a solver-specific redefinition of a global constraint, override "fzn_<global>.mzn" instead.


julia> value(x), value(y)
(0.0, 1.0)

julia> print(read("test.mzn", String))
include "alldifferent.mzn";
var bool: x;
var bool: y;
constraint alldifferent([x, y]);
constraint ((x \/ y) - 1) == false;
constraint ((x /\ y) - 0) == false;
solve satisfy;
```