### PR TITLE
Add more support for logical operators

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -496,11 +496,13 @@ end
 _INFIX_OPS = Dict(
     :- => "-",
     :+ => "+",
+    :* => "*",
     :(<) => "<",
     :(>) => ">",
     :(<=) => "<=",
     :(>=) => ">=",
     :(=>) => "->",
+    :⊻ => "xor",
 )
 
 _PREFIX_OPS = Dict(:(!) => "not")
@@ -520,10 +522,6 @@ function _write_call_expression(io, model, variables, expr)
         @assert op !== nothing
         print(io, op, "(")
         _write_expression(io, model, variables, expr.args[2])
-        for i in 3:length(expr.args)
-            print(io, ", ")
-            _write_expression(io, model, variables, expr.args[i])
-        end
         print(io, ")")
     end
     return

--- a/src/write.jl
+++ b/src/write.jl
@@ -493,24 +493,39 @@ function _write_logical_expression(io, model, variables, expr)
     return
 end
 
+_INFIX_OPS = Dict(
+    :- => "-",
+    :+ => "+",
+    :(<) => "<",
+    :(>) => ">",
+    :(<=) => "<=",
+    :(>=) => ">=",
+    :(=>) => "->",
+)
+
+_PREFIX_OPS = Dict(:(!) => "not")
+
 function _write_call_expression(io, model, variables, expr)
-    ops = Dict(
-        :- => "-",
-        :+ => "+",
-        :(<) => "<",
-        :(>) => ">",
-        :(<=) => "<=",
-        :(>=) => ">=",
-    )
-    op = get(ops, expr.args[1], nothing)
-    @assert op !== nothing
-    print(io, "(")
-    _write_expression(io, model, variables, expr.args[2])
-    for i in 3:length(expr.args)
-        print(io, " ", op, " ")
-        _write_expression(io, model, variables, expr.args[i])
+    op = get(_INFIX_OPS, expr.args[1], nothing)
+    if op !== nothing
+        print(io, "(")
+        _write_expression(io, model, variables, expr.args[2])
+        for i in 3:length(expr.args)
+            print(io, " ", op, " ")
+            _write_expression(io, model, variables, expr.args[i])
+        end
+        print(io, ")")
+    else
+        op = get(_PREFIX_OPS, expr.args[1], nothing)
+        @assert op !== nothing
+        print(io, op, "(")
+        _write_expression(io, model, variables, expr.args[2])
+        for i in 3:length(expr.args)
+            print(io, ", ")
+            _write_expression(io, model, variables, expr.args[i])
+        end
+        print(io, ")")
     end
-    print(io, ")")
     return
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1141,9 +1141,10 @@ function test_model_nlp_boolean_registered()
     nlp = MOI.Nonlinear.Model()
     f(args...) = error("evaluation not supported")
     MOI.Nonlinear.register_operator(nlp, :!, 1, f, f, f)
+    MOI.Nonlinear.register_operator(nlp, :⊻, 2, f, f, f)
     MOI.Nonlinear.register_operator(nlp, :(=>), 2, f, f, f)
     a, b, c = x
-    MOI.Nonlinear.add_constraint(nlp, :(($a => !($b || $c))), MOI.EqualTo(1.0))
+    MOI.Nonlinear.add_constraint(nlp, :(($a => !($b ⊻ $c))), MOI.EqualTo(1.0))
     backend = MOI.Nonlinear.ExprGraphOnly()
     evaluator = MOI.Nonlinear.Evaluator(nlp, backend, x)
     MOI.set(model, MOI.NLPBlock(), MOI.NLPBlockData(evaluator))
@@ -1156,7 +1157,7 @@ function test_model_nlp_boolean_registered()
     sol = round.(Bool, MOI.get(solver, MOI.VariablePrimal(), y))
     @test ifelse(sol[1], !(sol[2] || sol[3]), true)
     @test read("test.mzn", String) ==
-          "var bool: x1;\nvar bool: x2;\nvar bool: x3;\nconstraint (x1 -> not((x2 \\/ x3))) == true;\nsolve satisfy;\n"
+          "var bool: x1;\nvar bool: x2;\nvar bool: x3;\nconstraint (x1 -> not((x2 xor x3))) == true;\nsolve satisfy;\n"
     rm("test.mzn")
     return
 end


### PR DESCRIPTION
The demo is 
```Julia
julia> using JuMP

julia> import MiniZinc

julia> function register_symbol(model, sym, n)
           function f(args...)
               error(
                   "Unable to evaluate operator $(sym) with $(n) arguments because " *
                   "it was registered as a symbolic function only. Use `register` " * 
                   "to pass callbacks to evaluate the function and its derivatives.",
               )
           end
           register(model, sym, n, f, f, f)
           return
       end
register_symbol (generic function with 1 method)

julia> model = Model(() -> MiniZinc.Optimizer{Int}(MiniZinc.Chuffed()))
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: MiniZinc

julia> @variable(model, x, Bin)
x

julia> @variable(model, y, Bin)
y

julia> @variable(model, z, Bin)
z

julia> register_symbol(model, :(=>), 2)

julia> register_symbol(model, :(!), 1)

julia> @NLconstraint(model, (z => !(x || y)) == true)
(z => !(x || y)) - 1.0 = 0

julia> optimize!(model)
Warning: included file "count.mzn" overrides a global constraint file from the standard library. This is deprecated. For a solver-specific redefinition of a global constraint, override "fzn_<global>.mzn" instead.


julia> value.([x, y, z])
3-element Vector{Float64}:
 1.0
 1.0
 0.0
```

x-ref: https://github.com/jump-dev/JuMP.jl/issues/2227#issuecomment-1405993222