### PR TITLE
Update to v2.7.4

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,9 +1,0 @@
-[minizinc]
-git-tree-sha1 = "651dd7526ee64ca01c52c9f4aec3183657321b4e"
-arch = "x86_64"
-os = "macos"
-lazy = true
-
-    [[minizinc.download]]
-    url = "https://github.com/jump-dev/MiniZinc.jl/files/8913949/MiniZinc.x86_64-apple-darwin.tar.gz"
-    sha256 = "af0a89b2b3dcd6996c6bd706e9cf44bcaa4fc0bbcc8414bad977ed809118392a"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.2.1"
 
 [deps]
 Chuffed_jll = "77125aae-c893-5498-99e3-e30470bfa328"
-LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 MiniZinc_jll = "3677d96b-3d39-5184-a844-8e8b2839af35"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -13,7 +12,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 [compat]
 Chuffed_jll = "=0.10.4"
 MathOptInterface = "1.8"
-MiniZinc_jll = "2.6.2"
+MiniZinc_jll = "=2.7.4"
 julia = "1.6"
 
 [extras]

--- a/src/MiniZinc.jl
+++ b/src/MiniZinc.jl
@@ -6,11 +6,8 @@
 module MiniZinc
 
 import Chuffed_jll
-import LazyArtifacts
-import MathOptInterface
+import MathOptInterface as MOI
 import MiniZinc_jll
-
-const MOI = MathOptInterface
 
 const ReifiedLessThan{T} = MOI.Reified{MOI.LessThan{T}}
 const ReifiedGreaterThan{T} = MOI.Reified{MOI.GreaterThan{T}}

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -15,15 +15,6 @@ function run_flatzinc(solver_cmd::F, filename, args = String[]) where {F}
     end
 end
 
-function _artifact_path()
-    return joinpath(
-        LazyArtifacts.artifact"minizinc",
-        "MiniZinc.x86_64-apple-darwin",
-        "bin",
-        "minizinc",
-    )
-end
-
 """
     Optimizer{T}(solver_cmd) where {T}
 
@@ -51,10 +42,8 @@ function _minizinc_exe(f::F) where {F}
         else
             return f(joinpath(user_dir, "minizinc"))
         end
-    elseif Sys.islinux()
+    elseif Sys.islinux() || Sys.isapple()
         return MiniZinc_jll.minizinc(f)
-    elseif Sys.isapple()
-        return f(_artifact_path())
     end
     return error(
         "Unable to call libminizinc. Please manually install a copy and set " *

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,10 +7,8 @@ module TestMiniZinc
 
 using Test
 import Chuffed_jll
-import MathOptInterface
+import MathOptInterface as MOI
 import MiniZinc
-
-const MOI = MathOptInterface
 
 function runtests()
     for name in names(@__MODULE__; all = true)


### PR DESCRIPTION
x-ref #28

HiGHS isn't working yet. I likely need to change the compilation script. But this seemed to fix the issue on macOS, so I removed the artifact.