### PR TITLE
Implement solve_all for MiniZinc

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -202,7 +202,6 @@ function MOI.optimize!(dest::Optimizer{T}, src::MOI.ModelLike) where {T}
                         push!(dest.primal_solutions, copy(primal_solution))
                         empty!(primal_solution)
                     end
-                    continue
                 elseif m_var[1] == "_objective"
                     dest.primal_objective = _parse_result(T, m_var[2])
                 else

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -79,7 +79,6 @@ function _run_minizinc(dest::Optimizer)
     _stdout = joinpath(dir, "_stdout.txt")
     _minizinc_exe() do exe
         cmd = `$(exe) --solver $(dest.solver) --output-objective -o $(output) $(filename)`
-
         if dest.time_limit_sec !== nothing
             limit = round(Int, 1_000 * dest.time_limit_sec::Float64)
             cmd = `$cmd --time-limit $limit`

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -132,7 +132,8 @@ end
 
 function MOI.set(model::Optimizer, attr::MOI.RawOptimizerAttribute, value)
     if attr.name == "num_solutions" && !(value isa Int && value >= 1)
-        throw(MOI.SetAttributeNotAllowed("value must be an `Int` that is >= 1"))
+        msg = "value must be an `Int` that is >= 1"
+        throw(MOI.SetAttributeNotAllowed(attr, msg))
     end
     model.options[attr.name] = value
     return

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -77,7 +77,6 @@ function _run_minizinc(dest::Optimizer)
     end
     output = joinpath(dir, "model.ozn")
     _stdout = joinpath(dir, "_stdout.txt")
-
     _minizinc_exe() do exe
         cmd = `$(exe) --solver $(dest.solver) --output-objective -o $(output) $(filename)`
 

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -190,8 +190,6 @@ function MOI.optimize!(dest::Optimizer{T}, src::MOI.ModelLike) where {T}
             for line in split(ret, "\n")
                 m_var = match(r"(.+) \= (.+)\;", line)
                 if m_var === nothing
-                    isempty(primal_solution) ||
-                        push!(dest.primal_solutions, primal_solution) # add solution
                     if !isempty(primal_solution)
                         # We found a line in the output that is not a variable
                         # statement. It must divide the solutions, so append
@@ -263,9 +261,6 @@ function MOI.get(
 )
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, x)
-    if attr.result_index > length(model.primal_solutions)
-        throw(ErrorException("Result index out of bounds."))
-    end
     return model.primal_solutions[attr.result_index][x]
 end
 

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -84,7 +84,6 @@ function _run_minizinc(dest::Optimizer)
             limit = round(Int, 1_000 * dest.time_limit_sec::Float64)
             cmd = `$cmd --time-limit $limit`
         end
-
         if dest.options["num_solutions"] > 1
             cmd = `$cmd --num-solutions $(dest.options["num_solutions"])`
         end

--- a/test/examples/nqueens_solveall.jl
+++ b/test/examples/nqueens_solveall.jl
@@ -7,9 +7,8 @@
 # based on MiniZinc example nqueens.mzn
 # queen in column i is in row q[i]
 
-n = 8
-
 function _init_model()
+    n = 8
     model = MOI.instantiate(
         () -> MiniZinc.Optimizer{Int}("chuffed");
         with_cache_type = Int,
@@ -32,6 +31,7 @@ function _check_result(
     actual_count = 92,
     termination_status = MOI.OPTIMAL,
 )
+    n = 8
     @test MOI.get(model, MOI.TerminationStatus()) === termination_status
     res_count = MOI.get(model, MOI.ResultCount())
     @test res_count == actual_count

--- a/test/examples/nqueens_solveall.jl
+++ b/test/examples/nqueens_solveall.jl
@@ -1,0 +1,114 @@
+# Copyright (c) 2022 MiniZinc.jl contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+# N-queens example
+# based on MiniZinc example nqueens.mzn
+# queen in column i is in row q[i]
+
+n = 8
+
+function init_model()
+    model = MOI.instantiate(
+        () -> MiniZinc.Optimizer{Int}("chuffed");
+        with_cache_type = Int,
+        with_bridge_type = Int,
+    )
+    MOI.set(model, MOI.RawOptimizerAttribute("model_filename"), "test.mzn")
+    q = MOI.add_variables(model, n)
+    MOI.add_constraint.(model, q, MOI.Interval(1, n))
+    MOI.add_constraint(model, MOI.VectorOfVariables(q), MOI.AllDifferent(n))
+    for op in (+, -)
+        f = MOI.Utilities.vectorize([op(q[i], i) for i in eachindex(q)])
+        MOI.add_constraint(model, f, MOI.AllDifferent(n))
+    end
+
+    return model, q
+end
+
+function check_result(
+    model,
+    q,
+    actual_count = 92,
+    termination_status = MOI.OPTIMAL,
+)
+    @test MOI.get(model, MOI.TerminationStatus()) === termination_status
+    res_count = MOI.get(model, MOI.ResultCount())
+    @test res_count == actual_count
+
+    for i in 1:res_count
+        q_sol = MOI.get(model, MOI.VariablePrimal(i), q)
+        @test allunique(q_sol)
+        @test allunique(q_sol .+ (1:n))
+        @test allunique(q_sol .- (1:n))
+    end
+    @test MOI.get(model, MOI.SolveTimeSec()) < 4.0
+    return rm("test.mzn")
+end
+
+function run_nqueens(option)
+    if option == "solve_all1" # solve all
+        @info "test solve_all with num_solution not set"
+        model, q = init_model()
+        MOI.set(model, MOI.RawOptimizerAttribute("all_solutions"), true)
+        MOI.optimize!(model)
+        check_result(model, q)
+    elseif option == "solve_all2" # solve all with limit > 92
+        @info "test solve_all with limit > 92"
+        model, q = init_model()
+        MOI.set(model, MOI.RawOptimizerAttribute("all_solutions"), true)
+        MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 100)
+        MOI.optimize!(model)
+        check_result(model, q)
+    elseif option == "solve_all3" # solve all with limit = 25 
+        @info "test solve_all with limit = 25"
+        model, q = init_model()
+        MOI.set(model, MOI.RawOptimizerAttribute("all_solutions"), true)
+        MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 25)
+        MOI.optimize!(model)
+        check_result(model, q, 25, MOI.SOLUTION_LIMIT)
+    elseif option == "solve_one" # solve one
+        @info "test solve_one"
+        model, q = init_model()
+        MOI.set(model, MOI.RawOptimizerAttribute("all_solutions"), false)
+        MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 100)
+        MOI.optimize!(model)
+        check_result(model, q, 1)
+    elseif option == "throw"
+        @info "test throw"
+        model, q = init_model()
+        @test_throws ErrorException MOI.set(
+            model,
+            MOI.RawOptimizerAttribute("all_solutions"),
+            1,
+        )
+        @test_throws ErrorException MOI.set(
+            model,
+            MOI.RawOptimizerAttribute("num_solutions"),
+            -1,
+        )
+        @test_throws ErrorException MOI.set(
+            model,
+            MOI.RawOptimizerAttribute("num_solutions"),
+            0,
+        )
+        @test_throws ErrorException MOI.set(
+            model,
+            MOI.RawOptimizerAttribute("num_solutions"),
+            1.1,
+        )
+        @test_throws ErrorException MOI.set(
+            model,
+            MOI.RawOptimizerAttribute("num_solutions"),
+            "two",
+        )
+    end
+    return
+end
+
+test_nqueens1() = run_nqueens("solve_all1")
+test_nqueens2() = run_nqueens("solve_all2")
+test_nqueens3() = run_nqueens("solve_all3")
+test_nqueens4() = run_nqueens("solve_one")
+test_nqueens5() = run_nqueens("throw")

--- a/test/examples/nqueens_solveall.jl
+++ b/test/examples/nqueens_solveall.jl
@@ -23,7 +23,6 @@ function _init_model()
         f = MOI.Utilities.vectorize([op(q[i], i) for i in eachindex(q)])
         MOI.add_constraint(model, f, MOI.AllDifferent(n))
     end
-
     return model, q
 end
 
@@ -36,7 +35,6 @@ function _check_result(
     @test MOI.get(model, MOI.TerminationStatus()) === termination_status
     res_count = MOI.get(model, MOI.ResultCount())
     @test res_count == actual_count
-
     for i in 1:res_count
         q_sol = MOI.get(model, MOI.VariablePrimal(i), q)
         @test allunique(q_sol)

--- a/test/examples/nqueens_solveall.jl
+++ b/test/examples/nqueens_solveall.jl
@@ -47,7 +47,7 @@ function _check_result(
     return
 end
 
-function test_solve_all1() # solve all with limit > 92
+function test_nqueens_solve_all1() # solve all with limit > 92
     @info "test solve_all with limit > 92"
     model, q = _init_model()
     MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 100)
@@ -55,7 +55,7 @@ function test_solve_all1() # solve all with limit > 92
     return _check_result(model, q)
 end
 
-function test_solve_all2() # solve all with limit = 25 
+function test_nqueens_solve_all2() # solve all with limit = 25 
     @info "test solve_all with limit = 25"
     model, q = _init_model()
     MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 25)
@@ -63,14 +63,14 @@ function test_solve_all2() # solve all with limit = 25
     return _check_result(model, q, 25, MOI.SOLUTION_LIMIT)
 end
 
-function test_solve_one1() # solve one with limit not set
+function test_nqueens_solve_one1() # solve one with limit not set
     @info "test solve_one with limit not set"
     model, q = _init_model()
     MOI.optimize!(model)
     return _check_result(model, q, 1)
 end
 
-function test_solve_one2() # solve one with limit = 1
+function test_nqueens_solve_one2() # solve one with limit = 1
     @info "test solve_one with limit = 1"
     model, q = _init_model()
     MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 1)
@@ -78,7 +78,7 @@ function test_solve_one2() # solve one with limit = 1
     return _check_result(model, q, 1)
 end
 
-function test_throw() # test throw
+function test_nqueens_throw() # test throw
     @info "test throw"
     model, _ = _init_model()
     @test_throws ErrorException MOI.set(

--- a/test/examples/nqueens_solveall.jl
+++ b/test/examples/nqueens_solveall.jl
@@ -3,13 +3,13 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-# N-queens example
+# N-queens example - solve_all
 # based on MiniZinc example nqueens.mzn
 # queen in column i is in row q[i]
 
 n = 8
 
-function init_model()
+function _init_model()
     model = MOI.instantiate(
         () -> MiniZinc.Optimizer{Int}("chuffed");
         with_cache_type = Int,
@@ -27,7 +27,7 @@ function init_model()
     return model, q
 end
 
-function check_result(
+function _check_result(
     model,
     q,
     actual_count = 92,
@@ -43,72 +43,64 @@ function check_result(
         @test allunique(q_sol .+ (1:n))
         @test allunique(q_sol .- (1:n))
     end
-    @test MOI.get(model, MOI.SolveTimeSec()) < 4.0
-    return rm("test.mzn")
-end
 
-function run_nqueens(option)
-    if option == "solve_all1" # solve all
-        @info "test solve_all with num_solution not set"
-        model, q = init_model()
-        MOI.set(model, MOI.RawOptimizerAttribute("all_solutions"), true)
-        MOI.optimize!(model)
-        check_result(model, q)
-    elseif option == "solve_all2" # solve all with limit > 92
-        @info "test solve_all with limit > 92"
-        model, q = init_model()
-        MOI.set(model, MOI.RawOptimizerAttribute("all_solutions"), true)
-        MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 100)
-        MOI.optimize!(model)
-        check_result(model, q)
-    elseif option == "solve_all3" # solve all with limit = 25 
-        @info "test solve_all with limit = 25"
-        model, q = init_model()
-        MOI.set(model, MOI.RawOptimizerAttribute("all_solutions"), true)
-        MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 25)
-        MOI.optimize!(model)
-        check_result(model, q, 25, MOI.SOLUTION_LIMIT)
-    elseif option == "solve_one" # solve one
-        @info "test solve_one"
-        model, q = init_model()
-        MOI.set(model, MOI.RawOptimizerAttribute("all_solutions"), false)
-        MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 100)
-        MOI.optimize!(model)
-        check_result(model, q, 1)
-    elseif option == "throw"
-        @info "test throw"
-        model, q = init_model()
-        @test_throws ErrorException MOI.set(
-            model,
-            MOI.RawOptimizerAttribute("all_solutions"),
-            1,
-        )
-        @test_throws ErrorException MOI.set(
-            model,
-            MOI.RawOptimizerAttribute("num_solutions"),
-            -1,
-        )
-        @test_throws ErrorException MOI.set(
-            model,
-            MOI.RawOptimizerAttribute("num_solutions"),
-            0,
-        )
-        @test_throws ErrorException MOI.set(
-            model,
-            MOI.RawOptimizerAttribute("num_solutions"),
-            1.1,
-        )
-        @test_throws ErrorException MOI.set(
-            model,
-            MOI.RawOptimizerAttribute("num_solutions"),
-            "two",
-        )
-    end
+    @test MOI.get(model, MOI.SolveTimeSec()) < 4.0
+    rm("test.mzn")
     return
 end
 
-test_nqueens1() = run_nqueens("solve_all1")
-test_nqueens2() = run_nqueens("solve_all2")
-test_nqueens3() = run_nqueens("solve_all3")
-test_nqueens4() = run_nqueens("solve_one")
-test_nqueens5() = run_nqueens("throw")
+function test_solve_all1() # solve all with limit > 92
+    @info "test solve_all with limit > 92"
+    model, q = _init_model()
+    MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 100)
+    MOI.optimize!(model)
+    return _check_result(model, q)
+end
+
+function test_solve_all2() # solve all with limit = 25 
+    @info "test solve_all with limit = 25"
+    model, q = _init_model()
+    MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 25)
+    MOI.optimize!(model)
+    return _check_result(model, q, 25, MOI.SOLUTION_LIMIT)
+end
+
+function test_solve_one1() # solve one with limit not set
+    @info "test solve_one with limit not set"
+    model, q = _init_model()
+    MOI.optimize!(model)
+    return _check_result(model, q, 1)
+end
+
+function test_solve_one2() # solve one with limit = 1
+    @info "test solve_one with limit = 1"
+    model, q = _init_model()
+    MOI.set(model, MOI.RawOptimizerAttribute("num_solutions"), 1)
+    MOI.optimize!(model)
+    return _check_result(model, q, 1)
+end
+
+function test_throw() # test throw
+    @info "test throw"
+    model, _ = _init_model()
+    @test_throws ErrorException MOI.set(
+        model,
+        MOI.RawOptimizerAttribute("num_solutions"),
+        -1,
+    )
+    @test_throws ErrorException MOI.set(
+        model,
+        MOI.RawOptimizerAttribute("num_solutions"),
+        0,
+    )
+    @test_throws ErrorException MOI.set(
+        model,
+        MOI.RawOptimizerAttribute("num_solutions"),
+        1.1,
+    )
+    @test_throws ErrorException MOI.set(
+        model,
+        MOI.RawOptimizerAttribute("num_solutions"),
+        "two",
+    )
+end


### PR DESCRIPTION
Add option num_solutions

- num_solutions will be default to 1, unless it's set explicitly

- Changed primal_solution to primal_solutions to hold 1+ solutions

- Modified MOI.ResultCount, MOI.TerminationStatus.

- If num_solutions > 1 and we've found the given number of solutions, return MOI.SOLUTION_LIMIT, otherwise MOI.OPTIMAL

