### PR TITLE
Update reference to HiGHS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ julia> main()
 ## Use with JuMP
 
 You can also call MiniZinc from JuMP, using any solver that `libminizinc`
-supports. By default, MiniZinc.jl is compiled with `"highs"`:
+supports. By default, MiniZinc.jl is compiled with the
+[HiGHS](https://github.com/ERGO-Code/HiGHS) MILP solver,
+which can be selected by passing the `"highs"` parameter to `MiniZinc.Optimizer`:
 
 ```julia
 using JuMP


### PR DESCRIPTION
Hi,
This is a small change in MiniZinc.jl README because quickly reading through it for the first time, I had a doubt about the meaning of the "highs" solver. So I checked it's indeed HiGHS and updated the text to 1) add link to HiGHS and 2) state the fact it's a MILP solver.