### PR TITLE
Fix assumption about variable ordering in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1197,11 +1197,7 @@ function test_model_filename()
     @test MOI.get(solver, MOI.TerminationStatus()) === MOI.OPTIMAL
     @test MOI.get(solver, MOI.ResultCount()) >= 1
     @test MOI.get(solver, MOI.VariablePrimal(), index_map[x]) in [1, 2, 3]
-    _test_file_contents(
-        "test.mzn",
-        "var 1 .. 3: x1;\n",
-        "solve satisfy;\n",
-    )
+    _test_file_contents("test.mzn", "var 1 .. 3: x1;\n", "solve satisfy;\n")
     rm("test.mzn")
     return
 end


### PR DESCRIPTION
https://github.com/jump-dev/MathOptInterface.jl/pull/2495 may change the ordering of variables. The current behavior is an implementation detail, so we can make these tests more robust regardless.