### PR TITLE
Add instructions for CP-SAT in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ optimize!(model)
 @show value.(x)
 ```
 
+In order to use the CP-SAT solver from ORTools, use
+```julia
+import ORTools_jll
+path = joinpath(ORTools_jll.artifact_dir, "share", "minizinc", "solvers", "cp-sat.msc")
+model = Model(() -> MiniZinc.Optimizer{Float64}(path))
+```
+
 ## MathOptInterface API
 
 The MiniZinc `Optimizer{T}` supports the following constraints and attributes.


### PR DESCRIPTION
Thanks to the work of @dourouc05 on Yggdrasil, it's now easy to use CP-SAT from JuMP:
```julia
using JuMP
init_sol = [
    5 3 0 0 7 0 0 0 0
    6 0 0 1 9 5 0 0 0
    0 9 8 0 0 0 0 6 0
    8 0 0 0 6 0 0 0 3
    4 0 0 8 0 3 0 0 1
    7 0 0 0 2 0 0 0 6
    0 6 0 0 0 0 2 8 0
    0 0 0 4 1 9 0 0 5
    0 0 0 0 8 0 0 7 9
]
model = Model()
@variable(model, 1 <= x[1:9, 1:9] <= 9, Int)
@constraint(model, [i = 1:9], x[i, :] in MOI.AllDifferent(9));
@constraint(model, [j in 1:9], x[:, j] in MOI.AllDifferent(9));
for i in (0, 3, 6), j in (0, 3, 6)
    @constraint(model, vec(x[i.+(1:3), j.+(1:3)]) in MOI.AllDifferent(9))
end
for i in 1:9, j in 1:9
    if init_sol[i, j] != 0
        fix(x[i, j], init_sol[i, j]; force = true)
    end
end
import ORTools_jll
path = joinpath(ORTools_jll.artifact_dir, "share", "minizinc", "solvers", "cp-sat.msc")
set_optimizer(model, () -> MiniZinc.Optimizer{Float64}(path))
optimize!(model)
Int.(value.(x))
```
this gives
```
9×9 Matrix{Int64}:
 5  3  4  6  7  8  9  1  2
 6  7  2  1  9  5  3  4  8
 1  9  8  3  4  2  5  6  7
 8  5  9  7  6  1  4  2  3
 4  2  6  8  5  3  7  9  1
 7  1  3  9  2  4  8  5  6
 9  6  1  5  3  7  2  8  4
 2  8  7  4  1  9  6  3  5
 3  4  5  2  8  6  1  7  9
```
We can now consider whether we want to allow the user to just do `Optimizer{T}("cpset")` like we do with `chuffed` but that would require `ORTools_jll` to be a dependency of `MiniZinc` which might create issue with licenses (but the license of OR-Tools seems to be Apache v2 so I don't see any issue)