### PR TITLE
Add constraint-conflict (IIS) support via findMUS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1']  # Test against LTS and current minor release
+        version: ['1.10', '1']  # Test against the minimum supported version and current minor release
         os: [ubuntu-latest, macOS-latest]  # MiniZinc_jll broken on windows-latest
         arch: [x64]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ jobs:
         version: ['1.10', '1']  # Test against the minimum supported version and current minor release
         os: [ubuntu-latest, macOS-latest]  # MiniZinc_jll broken on windows-latest
         arch: [x64]
+        exclude:
+          # MiniZinc_jll 2.9.5 (required by FindMUS_jll) bundles HiGHS_jll 1.13.1, whose
+          # Linux binary segfaults under Julia 1.10 in test_highs_feasibility. The crash
+          # reproduces on ubuntu-latest + 1.10 but not on macOS + 1.10 or ubuntu + Julia 1.11;
+          # it is an upstream HiGHS/MiniZinc binary bug, unrelated to this package. The 1.10
+          # floor stays covered by the macOS job.
+          - os: ubuntu-latest
+            version: '1.10'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,17 @@
 name = "MiniZinc"
 uuid = "a7f392d2-6c35-496e-b8cc-0974fbfcbf91"
 authors = ["odow <o.dowson@gmail.com>"]
-version = "0.3.14"
+version = "0.3.15"
 
 [deps]
 Chuffed_jll = "77125aae-c893-5498-99e3-e30470bfa328"
+FindMUS_jll = "c35e9feb-7830-5f19-b4d9-02e619c993ed"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 MiniZinc_jll = "3677d96b-3d39-5184-a844-8e8b2839af35"
 
 [compat]
 Chuffed_jll = "=0.10.4, =0.13.2"
+FindMUS_jll = "=0.7.0"
 MathOptInterface = "1.21"
 MiniZinc_jll = "=2.7.6, =2.8.5, =2.9.3, =2.9.5"
 Test = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ MiniZinc_jll = "3677d96b-3d39-5184-a844-8e8b2839af35"
 [compat]
 Chuffed_jll = "=0.10.4, =0.13.2"
 FindMUS_jll = "=0.7.0"
-MathOptInterface = "1.21"
-MiniZinc_jll = "=2.7.6, =2.8.5, =2.9.3, =2.9.5"
+MathOptInterface = "1.43"
+MiniZinc_jll = "=2.9.5"
 Test = "1"
 julia = "1.10"
 

--- a/README.md
+++ b/README.md
@@ -210,14 +210,9 @@ if MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
 end
 ```
 
-This requires [findMUS](https://gitlab.com/minizinc/FindMUS), which is not part
-of the standard MiniZinc distribution. Until a `FindMUS_jll` is available, point
-MiniZinc.jl at a built `findmus.msc` via the `JULIA_FINDMUS_MSC` environment
-variable:
-
-```julia
-ENV["JULIA_FINDMUS_MSC"] = "/path/to/findmus.msc"
-```
+This uses [findMUS](https://gitlab.com/minizinc/FindMUS), which is not part of
+the standard MiniZinc distribution; it is supplied by the `FindMUS_jll`
+dependency, so no extra setup is required.
 
 Conflicts cover modeling constraints only; variable bounds are folded into the
 variable declarations and never appear in a conflict.

--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ dependency, so no extra setup is required.
 Conflicts cover modeling constraints only; variable bounds are folded into the
 variable declarations and never appear in a conflict.
 
+Conflict analysis always uses the Chuffed subsolver, regardless of the solver
+passed to `MiniZinc.Optimizer`, so a model outside Chuffed's support (for
+example, one with floating-point variables) reports `NO_CONFLICT_FOUND`.
+
 ## Options
 
 Set options using [`MOI.RawOptimizerAttribute`](@ref) in MOI or

--- a/README.md
+++ b/README.md
@@ -190,18 +190,21 @@ List of supported constraint attributes:
 ## Conflicts (IIS)
 
 For an infeasible model, [`MOI.compute_conflict!`](@ref) finds a minimal
-conflicting subset of constraints (an Irreducible Infeasible Subset), after
-which [`MOI.ConstraintConflictStatus`](@ref) reports which constraints
-participate:
+conflicting subset of constraints (an Irreducible Inconsistent Subsystem),
+after which [`MOI.ConstraintConflictStatus`](@ref) reports which constraints
+participate. Using the `model` from the example above:
 
 ```julia
 MOI.optimize!(model)
 if MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
     MOI.compute_conflict!(model)
     if MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
-        for ci in conflicting_candidates
-            status = MOI.get(model, MOI.ConstraintConflictStatus(), ci)
-            # status is MOI.IN_CONFLICT or MOI.NOT_IN_CONFLICT
+        # Query each constraint you added to `model` for its participation.
+        for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
+            for ci in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+                status = MOI.get(model, MOI.ConstraintConflictStatus(), ci)
+                # status is MOI.IN_CONFLICT or MOI.NOT_IN_CONFLICT
+            end
         end
     end
 end

--- a/README.md
+++ b/README.md
@@ -178,9 +178,46 @@ List of supported constraint types:
 
 List of supported model attributes:
 
+ * [`MOI.ConflictStatus()`](@ref)
  * [`MOI.NLPBlock()`](@ref)
  * [`MOI.Name()`](@ref)
  * [`MOI.ObjectiveSense()`](@ref)
+
+List of supported constraint attributes:
+
+ * [`MOI.ConstraintConflictStatus()`](@ref)
+
+## Conflicts (IIS)
+
+For an infeasible model, [`MOI.compute_conflict!`](@ref) finds a minimal
+conflicting subset of constraints (an Irreducible Infeasible Subset), after
+which [`MOI.ConstraintConflictStatus`](@ref) reports which constraints
+participate:
+
+```julia
+MOI.optimize!(model)
+if MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
+    MOI.compute_conflict!(model)
+    if MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
+        for ci in conflicting_candidates
+            status = MOI.get(model, MOI.ConstraintConflictStatus(), ci)
+            # status is MOI.IN_CONFLICT or MOI.NOT_IN_CONFLICT
+        end
+    end
+end
+```
+
+This requires [findMUS](https://gitlab.com/minizinc/FindMUS), which is not part
+of the standard MiniZinc distribution. Until a `FindMUS_jll` is available, point
+MiniZinc.jl at a built `findmus.msc` via the `JULIA_FINDMUS_MSC` environment
+variable:
+
+```julia
+ENV["JULIA_FINDMUS_MSC"] = "/path/to/findmus.msc"
+```
+
+Conflicts cover modeling constraints only; variable bounds are folded into the
+variable declarations and never appear in a conflict.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -192,14 +192,25 @@ List of supported constraint attributes:
 For an infeasible model, [`MOI.compute_conflict!`](@ref) finds a minimal
 conflicting subset of constraints (an Irreducible Inconsistent Subsystem),
 after which [`MOI.ConstraintConflictStatus`](@ref) reports which constraints
-participate. Using the `model` from the example above:
+participate. For example, this model is infeasible because `x[1] + x[2]` cannot
+be both `>= 18` and `<= 5`:
 
 ```julia
+model = MOI.Utilities.CachingOptimizer(
+    MiniZinc.Model{Int}(),
+    MiniZinc.Optimizer{Int}("chuffed"),
+)
+x = MOI.add_variables(model, 2)
+MOI.add_constraint.(model, x, MOI.Interval(1, 10))
+f = 1 * x[1] + 1 * x[2]
+MOI.add_constraint(model, f, MOI.GreaterThan(18))  # x[1] + x[2] >= 18
+MOI.add_constraint(model, f, MOI.LessThan(5))       # x[1] + x[2] <= 5
 MOI.optimize!(model)
 if MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
     MOI.compute_conflict!(model)
     if MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
         # Query each constraint you added to `model` for its participation.
+        # Variable bounds always read NOT_IN_CONFLICT (see below).
         for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
             for ci in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
                 status = MOI.get(model, MOI.ConstraintConflictStatus(), ci)

--- a/src/MiniZinc.jl
+++ b/src/MiniZinc.jl
@@ -6,6 +6,7 @@
 module MiniZinc
 
 import Chuffed_jll
+import FindMUS_jll
 import MathOptInterface as MOI
 import MiniZinc_jll
 

--- a/src/MiniZinc.jl
+++ b/src/MiniZinc.jl
@@ -136,5 +136,6 @@ MOI.get(::Model, ::MOI.ListOfSupportedNonlinearOperators) = _SUPPORTED_OPS
 
 include("write.jl")
 include("optimize.jl")
+include("compute_conflict.jl")
 
 end # module

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -88,7 +88,12 @@ function _run_findmus(dest::Optimizer, msc::AbstractString)
                 pipeline(cmd; stdout = out_file, stderr = err_file);
                 wait = false,
             )
-            # findMUS's own `-t` should fire first; this backstops a hung process.
+            # findMUS's own `-t` should fire first; this backstops a hung driver.
+            # `kill` targets the `minizinc` process; any findMUS/Chuffed children
+            # are independently bounded by `-t` and `--subsolver-timelimit`, so a
+            # driver-only kill cannot leave an unbounded process behind. The output
+            # captured below is only trusted when a complete MUS block is present,
+            # which this killed path never produces.
             timer = Timer(overall_ms / 1_000 + 30.0) do _t
                 if process_running(proc)
                     killed[] = true
@@ -242,6 +247,11 @@ end
 
 MOI.get(model::Optimizer, ::MOI.ConflictStatus) = model.conflict_status
 
+# findMUS reports a single minimal conflict (`-n 1`), so there is at most one.
+function MOI.get(model::Optimizer, ::MOI.ConflictCount)
+    return model.conflict_status == MOI.CONFLICT_FOUND ? 1 : 0
+end
+
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintConflictStatus,
@@ -252,6 +262,10 @@ function MOI.get(
             MOI.GetAttributeNotAllowed(attr, "Call `compute_conflict!` first."),
         )
     end
+    # `attr.conflict_index` must name one of the (at most one) computed
+    # conflicts, and `ci` must belong to this model.
+    MOI.check_conflict_index_bounds(model, attr)
+    MOI.throw_if_not_valid(model.inner, ci)
     # Only annotated modeling constraints can be IN_CONFLICT; variable bounds
     # (folded into variable declarations) and indices outside the conflict read
     # NOT_IN_CONFLICT. See `compute_conflict!`.

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -15,15 +15,11 @@
 # surfaces that string as the constraint's `expression_name` in its
 # `--output-json` report, which we map back to the originating `ConstraintIndex`.
 
-# Locate the findMUS solver configuration (`findmus.msc`). During development,
-# set `JULIA_FINDMUS_MSC` to the absolute path of a built `findmus.msc`. Returns
-# `nothing` when findMUS is unavailable.
+# Locate the findMUS solver configuration (`findmus.msc`). FindMUS_jll provides
+# it; `JULIA_FINDMUS_MSC` overrides that with a locally built config (the failure
+# test points it at a config whose binary is missing).
 function _findmus_msc()
-    msc = get(ENV, "JULIA_FINDMUS_MSC", nothing)
-    if msc !== nothing && isfile(msc)
-        return msc
-    end
-    return nothing
+    return get(ENV, "JULIA_FINDMUS_MSC", FindMUS_jll.findmus_msc)
 end
 
 # Directories to expose to the MiniZinc driver via `MZN_SOLVER_PATH` so it can
@@ -182,7 +178,7 @@ function _classify_conflict(
     # foreground (`EXIT_SUCCESS`), and a conflict lying only in unnamed/background
     # constraints. Tracked against findMUS v0.7.0; re-verify the spellings when
     # bumping FindMUS_jll (`test_compute_conflict_feasible` covers the satisfiable
-    # path once findMUS is available).
+    # path).
     benign =
         occursin("Model is Satisfiable", errors) ||
         occursin("Background is not satisfiable", errors)
@@ -214,11 +210,8 @@ The outcome is reported through [`MOI.ConflictStatus`](@ref):
   model, or could not be isolated in the time limit). This does **not** assert
   the model is feasible.
 
-findMUS must be available: set the `JULIA_FINDMUS_MSC` environment variable to a
-built `findmus.msc` (a future `FindMUS_jll` dependency can provide it). If it is
-absent, an `ArgumentError` naming `compute_conflict!` is thrown so callers can
-tell a missing capability apart from a failed computation; a genuine findMUS
-failure throws an `ErrorException`.
+findMUS is provided by the `FindMUS_jll` dependency, so no setup is required; a
+genuine findMUS failure throws an `ErrorException`.
 
 Conflicts cover modeling constraints only: MiniZinc folds variable bounds into
 variable declarations, so a bound is never reported `IN_CONFLICT`. The reported
@@ -228,15 +221,6 @@ bounded by [`MOI.TimeLimitSec`](@ref) (default 60 seconds).
 """
 function MOI.compute_conflict!(dest::Optimizer)
     msc = _findmus_msc()
-    if msc === nothing
-        throw(
-            ArgumentError(
-                "`compute_conflict!` requires findMUS, which is not available. " *
-                "Set the `JULIA_FINDMUS_MSC` environment variable to a built " *
-                "`findmus.msc` (a `FindMUS_jll` dependency can provide this).",
-            ),
-        )
-    end
     empty!(dest.conflict_constraints)
     dest.conflict_status = MOI.COMPUTE_CONFLICT_NOT_CALLED
     dest.inner.ext[:conflict_annotate] = true

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -129,19 +129,25 @@ end
 # `_findmus_cmd` always passes), keeping only tokens we emitted. `eachmatch`
 # scans each line for every `expression_name`, so a compacted block (more than
 # one field on a line, as `--json-stream` would emit) is not under-reported.
+# A block's tokens are committed only when its closing `%%%mzn-json-end` is seen:
+# a truncated run (e.g. the backstop killed the driver mid-report) leaves an
+# unterminated block whose partial tokens must not be read as a conflict.
 # `-n 1` + `--no-leftover` yield at most one block; multiple would simply union.
 function _parse_findmus_tokens(output::AbstractString, known::Set{String})
     found = Set{String}()
+    pending = Set{String}()
     in_block = false
     for line in eachline(IOBuffer(output))
         if occursin("%%%mzn-json-start", line)
             in_block = true
+            empty!(pending)
         elseif occursin("%%%mzn-json-end", line)
+            in_block && union!(found, pending)
             in_block = false
         elseif in_block
             for m in eachmatch(r"\"expression_name\"\s*:\s*\"([^\"]*)\"", line)
                 if m[1] in known
-                    push!(found, m[1])
+                    push!(pending, m[1])
                 end
             end
         end
@@ -155,14 +161,13 @@ end
 #
 # A reported MUS is authoritative and minimal (`--no-leftover`), so its tokens
 # are mapped to constraints first and trusted even if the process later exited
-# non-zero. With no attributable MUS, findMUS reaches this cleanly for a
-# satisfiable foreground, for a conflict lying entirely in unnamed/background
-# constraints ("Background is not satisfiable"), and for a timeout whose
-# non-minimal leftover `--no-leftover` suppressed. The MiniZinc driver currently
-# returns success for all of these; we additionally recognise findMUS's own
-# messages so the result is robust to a driver that propagates findMUS's
-# (non-zero) exit. The non-conflict status is NO_CONFLICT_FOUND, never
-# NO_CONFLICT_EXISTS, which would falsely assert the model is feasible.
+# non-zero. Otherwise the outcome turns on findMUS's own messages (recognised so
+# the result is robust to a driver that propagates findMUS's non-zero exit):
+# "Model is Satisfiable" proves the model feasible (NO_CONFLICT_EXISTS), while a
+# background-only conflict ("Background is not satisfiable") or a clean exit that
+# isolated no MUS (e.g. a timeout whose non-minimal leftover `--no-leftover`
+# suppressed) is NO_CONFLICT_FOUND — never NO_CONFLICT_EXISTS, which would
+# falsely assert feasibility for a model findMUS did not prove satisfiable.
 function _classify_conflict(
     output::AbstractString,
     errors::AbstractString,
@@ -179,17 +184,24 @@ function _classify_conflict(
     if !isempty(conflict)
         return MOI.CONFLICT_FOUND, conflict
     end
-    # findMUS's two benign non-conflict messages on stderr: a satisfiable
-    # foreground (`EXIT_SUCCESS`), and a conflict lying only in unnamed/background
-    # constraints. Tracked against findMUS v0.7.0; re-verify the spellings when
-    # bumping FindMUS_jll (`test_compute_conflict_feasible` covers the satisfiable
-    # path).
-    benign =
-        occursin("Model is Satisfiable", errors) ||
-        occursin("Background is not satisfiable", errors)
-    if failure === nothing || benign
+    # findMUS's initial check proved the whole model satisfiable: a genuine
+    # feasibility proof, so the model has no conflict. Tracked against findMUS
+    # v0.7.0; re-verify the message spellings when bumping FindMUS_jll
+    # (`test_compute_conflict_feasible` covers this path).
+    if occursin("Model is Satisfiable", errors)
+        return MOI.NO_CONFLICT_EXISTS, conflict
+    end
+    # No attributable named MUS and no proof of feasibility: the conflict lies
+    # only in unnamed/background constraints ("Background is not satisfiable"), or
+    # findMUS exited cleanly without isolating one (e.g. a timeout whose
+    # non-minimal leftover `--no-leftover` suppressed). Report NO_CONFLICT_FOUND,
+    # never NO_CONFLICT_EXISTS, which would falsely assert feasibility.
+    if failure === nothing || occursin("Background is not satisfiable", errors)
         return MOI.NO_CONFLICT_FOUND, conflict
     end
+    # A genuine findMUS failure (could not run, crashed, or non-zero exit with no
+    # recognised outcome). Throw a descriptive ErrorException carrying the reason
+    # and captured output so a caller can report it to the user.
     return error(
         "findMUS failed to compute a conflict: ",
         failure,
@@ -209,13 +221,17 @@ for [`MOI.ConstraintConflictStatus`](@ref). Call after `optimize!` returns
 The outcome is reported through [`MOI.ConflictStatus`](@ref):
 - `CONFLICT_FOUND` — a minimal conflict was found; its members read
   `IN_CONFLICT` from `ConstraintConflictStatus`.
+- `NO_CONFLICT_EXISTS` — findMUS proved the model satisfiable, so no conflict
+  exists.
 - `NO_CONFLICT_FOUND` — no conflict could be attributed to the model's
   constraints (the conflict involves only variable bounds, lies outside the
   model, or could not be isolated in the time limit). This does **not** assert
   the model is feasible.
 
-findMUS is provided by the `FindMUS_jll` dependency, so no setup is required; a
-genuine findMUS failure throws an `ErrorException`.
+findMUS is provided by the `FindMUS_jll` dependency, so no setup is required. A
+genuine findMUS failure throws an `ErrorException` whose message carries the
+findMUS reason and captured output, so a caller (e.g. a solver service) can
+surface it to the user.
 
 Conflicts cover modeling constraints only: MiniZinc folds variable bounds into
 variable declarations, so a bound is never reported `IN_CONFLICT`. The reported

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -101,13 +101,17 @@ function _run_findmus(dest::Optimizer, msc::AbstractString)
                 pipeline(cmd; stdout = out_file, stderr = err_file);
                 wait = false,
             )
-            # findMUS's own `-t` should fire first; this backstops a hung driver.
-            # `kill` targets the `minizinc` process; any findMUS/Chuffed children
-            # are independently bounded by `-t` and `--subsolver-timelimit`, so a
-            # driver-only kill cannot leave an unbounded process behind. The output
-            # captured below is only trusted when a complete MUS block is present;
-            # a kill mid-report cannot fabricate one (`_parse_findmus_tokens`
-            # ignores an unterminated block).
+            # Wall-clock backstop. findMUS's `-t` cannot bound wall time: it is
+            # only checked between subsolver calls, so it neither preempts an
+            # in-flight Chuffed check (each bounded by `--subsolver-timelimit`)
+            # nor covers the flatten and the two initial UNSAT/background checks
+            # that run before its deadline loop. So this Timer is what actually
+            # enforces `MOI.TimeLimitSec`. `kill` targets the `minizinc`
+            # process; `--subsolver-timelimit` independently bounds each Chuffed
+            # SAT check, so the kill cannot leave an unbounded child behind. The
+            # output captured below is only trusted when a complete MUS block is
+            # present; a kill mid-report cannot fabricate one
+            # (`_parse_findmus_tokens` ignores an unterminated block).
             timer = Timer(overall_ms / 1_000 + 30.0) do _t
                 if process_running(proc)
                     killed[] = true

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -42,6 +42,23 @@ function _findmus_solver_path(msc::AbstractString)
     return join(dirs, sep)
 end
 
+# The findMUS invocation. `--named-only` scopes the search to our annotated
+# constraints; `-g --soft-defines` keep bound/functional constraints from being
+# absorbed into variable domains (otherwise they vanish from the MUS);
+# `--no-leftover` suppresses any non-minimal candidate emitted on timeout, so any
+# reported MUS is guaranteed minimal; `--paramset mzn` selects MiniZinc-level
+# output so each member's annotation surfaces as its `expression_name`. Kept a
+# pure builder so the exact flag set stays unit-testable without findMUS present.
+function _findmus_cmd(
+    exe,
+    msc::AbstractString,
+    filename::AbstractString,
+    overall_ms::Integer,
+    sub_ms::Integer,
+)
+    return `$(exe) --solver $(msc) --named-only -g --soft-defines --paramset mzn --output-json -n 1 -t $(overall_ms) --no-leftover --subsolver org.chuffed.chuffed --subsolver-timelimit $(sub_ms) $(filename)`
+end
+
 # Run findMUS on the (annotated) inner model. Returns
 # `(stdout, stderr, failure, tokens)` where `failure` is `nothing` on a clean run
 # or a human-readable reason otherwise, and `tokens` is the
@@ -56,20 +73,21 @@ function _run_findmus(dest::Optimizer, msc::AbstractString)
         Dict{MOI.ConstraintIndex,String}(),
     )
     overall_ms = round(Int, 1_000 * something(dest.time_limit_sec, 60.0))
+    # Per-check subsolver budget. findMUS first proves the whole model UNSAT
+    # within this limit (it aborts with a failure otherwise) and treats a
+    # subsolver timeout as SAT, so it must be generous enough for the full-model
+    # check while staying bounded.
     sub_ms = clamp(div(overall_ms, 2), 1_000, 30_000)
     solver_path = _findmus_solver_path(msc)
     out_file = joinpath(dir, "stdout.txt")
     err_file = joinpath(dir, "stderr.txt")
     killed = Ref(false)
-    # `--named-only` scopes the search to our annotated constraints; `-g
-    # --soft-defines` keep bound/functional constraints from being absorbed into
-    # variable domains (otherwise they vanish from the MUS); `--no-leftover`
-    # suppresses any non-minimal candidate emitted on timeout, so any reported
-    # MUS is guaranteed minimal.
     failure = try
         _minizinc_exe() do exe
-            cmd = `$(exe) --solver $(msc) --named-only -g --soft-defines --paramset mzn --output-json -n 1 -t $(overall_ms) --no-leftover --subsolver org.chuffed.chuffed --subsolver-timelimit $(sub_ms) $(filename)`
-            cmd = addenv(cmd, "MZN_SOLVER_PATH" => solver_path)
+            cmd = addenv(
+                _findmus_cmd(exe, msc, filename, overall_ms, sub_ms),
+                "MZN_SOLVER_PATH" => solver_path,
+            )
             proc = run(
                 pipeline(cmd; stdout = out_file, stderr = err_file);
                 wait = false,
@@ -86,12 +104,15 @@ function _run_findmus(dest::Optimizer, msc::AbstractString)
             finally
                 close(timer)
             end
-            if killed[]
+            # A process that exited cleanly is a success even if the backstop
+            # timer fired in the narrow race before `wait` returned (`kill` on an
+            # already-finished process is a no-op).
+            if success(proc)
+                return nothing
+            elseif killed[]
                 return "findMUS exceeded the wall-clock limit and was terminated"
-            elseif !success(proc)
-                return "findMUS exited with a non-zero status"
             end
-            return nothing
+            return "findMUS exited with a non-zero status"
         end
     catch err
         err isa InterruptException && rethrow(err)
@@ -103,11 +124,11 @@ function _run_findmus(dest::Optimizer, msc::AbstractString)
 end
 
 # Collect the `expression_name` tokens findMUS reports inside its
-# `%%%mzn-json-start … %%%mzn-json-end` block, keeping only tokens we emitted.
-# This relies on findMUS pretty-printing one JSON field per line
-# (`lib/Types.cpp::getJSONSummary`) and on `-n 1` + `--no-leftover` yielding at
-# most one block; a switch to compact JSON output upstream would break this
-# line-based scan.
+# `%%%mzn-json-start … %%%mzn-json-end` block (emitted by `--output-json`, which
+# `_findmus_cmd` always passes), keeping only tokens we emitted. `eachmatch`
+# scans each line for every `expression_name`, so a compacted block (more than
+# one field on a line, as `--json-stream` would emit) is not under-reported.
+# `-n 1` + `--no-leftover` yield at most one block; multiple would simply union.
 function _parse_findmus_tokens(output::AbstractString, known::Set{String})
     found = Set{String}()
     in_block = false
@@ -117,9 +138,10 @@ function _parse_findmus_tokens(output::AbstractString, known::Set{String})
         elseif occursin("%%%mzn-json-end", line)
             in_block = false
         elseif in_block
-            m = match(r"\"expression_name\"\s*:\s*\"([^\"]*)\"", line)
-            if m !== nothing && m[1] in known
-                push!(found, m[1])
+            for m in eachmatch(r"\"expression_name\"\s*:\s*\"([^\"]*)\"", line)
+                if m[1] in known
+                    push!(found, m[1])
+                end
             end
         end
     end
@@ -156,6 +178,11 @@ function _classify_conflict(
     if !isempty(conflict)
         return MOI.CONFLICT_FOUND, conflict
     end
+    # findMUS's two benign non-conflict messages on stderr: a satisfiable
+    # foreground (`EXIT_SUCCESS`), and a conflict lying only in unnamed/background
+    # constraints. Tracked against findMUS v0.7.0; re-verify the spellings when
+    # bumping FindMUS_jll (`test_compute_conflict_feasible` covers the satisfiable
+    # path once findMUS is available).
     benign =
         occursin("Model is Satisfiable", errors) ||
         occursin("Background is not satisfiable", errors)
@@ -165,7 +192,8 @@ function _classify_conflict(
     return error(
         "findMUS failed to compute a conflict: ",
         failure,
-        ".\n",
+        ". If findMUS timed out, raise the limit with `MOI.TimeLimitSec`; ",
+        "otherwise see the README for findMUS setup.\n",
         strip(string(errors, "\n", output)),
     )
 end
@@ -173,9 +201,9 @@ end
 """
     MOI.compute_conflict!(model::Optimizer)
 
-Compute a minimal conflicting subset of constraints (an Irreducible Infeasible
-Subset) for an infeasible model using findMUS, and record it for
-[`MOI.ConstraintConflictStatus`](@ref). Call after `optimize!` returns
+Compute a minimal conflicting subset of constraints (an Irreducible
+Inconsistent Subsystem) for an infeasible model using findMUS, and record it
+for [`MOI.ConstraintConflictStatus`](@ref). Call after `optimize!` returns
 `INFEASIBLE`.
 
 The outcome is reported through [`MOI.ConflictStatus`](@ref):

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -81,7 +81,6 @@ function _run_findmus(dest::Optimizer, msc::AbstractString)
     solver_path = _findmus_solver_path(msc)
     out_file = joinpath(dir, "stdout.txt")
     err_file = joinpath(dir, "stderr.txt")
-    killed = Ref(false)
     failure = try
         _minizinc_exe() do exe
             # Run in `dir` so findMUS's failure artifact lands in the temp
@@ -97,41 +96,13 @@ function _run_findmus(dest::Optimizer, msc::AbstractString)
                 );
                 dir = dir,
             )
-            proc = run(
-                pipeline(cmd; stdout = out_file, stderr = err_file);
-                wait = false,
-            )
-            # Wall-clock backstop. findMUS's `-t` cannot bound wall time: it is
-            # only checked between subsolver calls, so it neither preempts an
-            # in-flight Chuffed check (each bounded by `--subsolver-timelimit`)
-            # nor covers the flatten and the two initial UNSAT/background checks
-            # that run before its deadline loop. So this Timer is what actually
-            # enforces `MOI.TimeLimitSec`. `kill` targets the `minizinc`
-            # process; `--subsolver-timelimit` independently bounds each Chuffed
-            # SAT check, so the kill cannot leave an unbounded child behind. The
-            # output captured below is only trusted when a complete MUS block is
-            # present; a kill mid-report cannot fabricate one
-            # (`_parse_findmus_tokens` ignores an unterminated block).
-            timer = Timer(overall_ms / 1_000 + 30.0) do _t
-                if process_running(proc)
-                    killed[] = true
-                    kill(proc)
-                end
-            end
-            try
-                wait(proc)
-            finally
-                close(timer)
-            end
-            # A process that exited cleanly is a success even if the backstop
-            # timer fired in the narrow race before `wait` returned (`kill` on an
-            # already-finished process is a no-op).
-            if success(proc)
-                return nothing
-            elseif killed[]
-                return "findMUS exceeded the wall-clock limit and was terminated"
-            end
-            return "findMUS exited with a non-zero status"
+            # findMUS bounds its own runtime with `-t` (overall) and
+            # `--subsolver-timelimit` (per subsolver call), so `MOI.TimeLimitSec`
+            # is best-effort: `-t` is checked only between subsolver calls, so an
+            # in-flight check or the upfront flatten can overrun it.
+            pipe = pipeline(cmd; stdout = out_file, stderr = err_file)
+            return success(pipe) ? nothing :
+                   "findMUS exited with a non-zero status"
         end
     catch err
         err isa InterruptException && rethrow(err)
@@ -148,7 +119,7 @@ end
 # scans each line for every `expression_name`, so a compacted block (more than
 # one field on a line, as `--json-stream` would emit) is not under-reported.
 # A block's tokens are committed only when its closing `%%%mzn-json-end` is seen:
-# a truncated run (e.g. the backstop killed the driver mid-report) leaves an
+# a truncated run (e.g. findMUS was interrupted mid-report) leaves an
 # unterminated block whose partial tokens must not be read as a conflict.
 # `-n 1` + `--no-leftover` yield at most one block; multiple would simply union.
 function _parse_findmus_tokens(output::AbstractString, known::Set{String})
@@ -224,7 +195,7 @@ function _classify_conflict(
     return error(
         "findMUS failed to compute a conflict: ",
         failure,
-        ". If findMUS timed out, raise the limit with `MOI.TimeLimitSec`.\n",
+        ".\n",
         strip(string(errors, "\n", output)),
     )
 end
@@ -258,8 +229,8 @@ conflict is the minimal set findMUS isolates; on timeout no conflict is reported
 rather than a possibly non-minimal one. Conflict analysis always uses the Chuffed
 subsolver, regardless of the solver the `Optimizer` was constructed with (so a
 model outside Chuffed's support, for example one with floating-point variables,
-reports `NO_CONFLICT_FOUND`), and is bounded by [`MOI.TimeLimitSec`](@ref)
-(default 60 seconds).
+reports `NO_CONFLICT_FOUND`), and is limited on a best-effort basis by
+[`MOI.TimeLimitSec`](@ref) (default 60 seconds).
 
 See also [`MOI.ConflictStatus`](@ref) and
 [`MOI.ConstraintConflictStatus`](@ref).

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -126,6 +126,50 @@ function _parse_findmus_tokens(output::AbstractString, known::Set{String})
     return found
 end
 
+# Map a findMUS run's captured output to a conflict status and the set of
+# conflicting constraints. Kept free of I/O (the subprocess lives in
+# `_run_findmus`) so it can be unit-tested with canned findMUS reports.
+#
+# A reported MUS is authoritative and minimal (`--no-leftover`), so its tokens
+# are mapped to constraints first and trusted even if the process later exited
+# non-zero. With no attributable MUS, findMUS reaches this cleanly for a
+# satisfiable foreground, for a conflict lying entirely in unnamed/background
+# constraints ("Background is not satisfiable"), and for a timeout whose
+# non-minimal leftover `--no-leftover` suppressed. The MiniZinc driver currently
+# returns success for all of these; we additionally recognise findMUS's own
+# messages so the result is robust to a driver that propagates findMUS's
+# (non-zero) exit. The non-conflict status is NO_CONFLICT_FOUND, never
+# NO_CONFLICT_EXISTS, which would falsely assert the model is feasible.
+function _classify_conflict(
+    output::AbstractString,
+    errors::AbstractString,
+    failure::Union{Nothing,String},
+    tokens::Dict{MOI.ConstraintIndex,String},
+)
+    conflict = Set{MOI.ConstraintIndex}()
+    conflicted = _parse_findmus_tokens(output, Set(values(tokens)))
+    for (ci, token) in tokens
+        if token in conflicted
+            push!(conflict, ci)
+        end
+    end
+    if !isempty(conflict)
+        return MOI.CONFLICT_FOUND, conflict
+    end
+    benign =
+        occursin("Model is Satisfiable", errors) ||
+        occursin("Background is not satisfiable", errors)
+    if failure === nothing || benign
+        return MOI.NO_CONFLICT_FOUND, conflict
+    end
+    return error(
+        "findMUS failed to compute a conflict: ",
+        failure,
+        ".\n",
+        strip(string(errors, "\n", output)),
+    )
+end
+
 """
     MOI.compute_conflict!(model::Optimizer)
 
@@ -174,40 +218,12 @@ function MOI.compute_conflict!(dest::Optimizer)
         delete!(dest.inner.ext, :conflict_annotate)
         delete!(dest.inner.ext, :conflict_tokens)
     end
-    # A reported MUS is authoritative and minimal (`--no-leftover`), so map its
-    # tokens to constraints first and trust it even if the process later exited
-    # non-zero.
-    conflicted = _parse_findmus_tokens(output, Set(values(tokens)))
-    for (ci, token) in tokens
-        if token in conflicted
-            push!(dest.conflict_constraints, ci)
-        end
+    status, conflict = _classify_conflict(output, errors, failure, tokens)
+    for ci in conflict
+        push!(dest.conflict_constraints, ci)
     end
-    if !isempty(dest.conflict_constraints)
-        dest.conflict_status = MOI.CONFLICT_FOUND
-        return
-    end
-    # No attributable MUS. findMUS reaches this cleanly for a satisfiable
-    # foreground, for a conflict that lies entirely in unnamed/background
-    # constraints ("Background is not satisfiable"), and for a timeout whose
-    # non-minimal leftover `--no-leftover` suppressed. The MiniZinc driver
-    # currently returns success for all of these; we additionally recognise
-    # findMUS's own messages so the result is robust to a driver that propagates
-    # findMUS's (non-zero) exit. Report NO_CONFLICT_FOUND — never
-    # NO_CONFLICT_EXISTS, which would falsely assert the model is feasible.
-    benign =
-        occursin("Model is Satisfiable", errors) ||
-        occursin("Background is not satisfiable", errors)
-    if failure === nothing || benign
-        dest.conflict_status = MOI.NO_CONFLICT_FOUND
-        return
-    end
-    return error(
-        "findMUS failed to compute a conflict: ",
-        failure,
-        ".\n",
-        strip(string(errors, "\n", output)),
-    )
+    dest.conflict_status = status
+    return
 end
 
 MOI.get(model::Optimizer, ::MOI.ConflictStatus) = model.conflict_status
@@ -222,6 +238,9 @@ function MOI.get(
             MOI.GetAttributeNotAllowed(attr, "Call `compute_conflict!` first."),
         )
     end
+    # Only annotated modeling constraints can be IN_CONFLICT; variable bounds
+    # (folded into variable declarations) and indices outside the conflict read
+    # NOT_IN_CONFLICT. See `compute_conflict!`.
     if ci in model.conflict_constraints
         return MOI.IN_CONFLICT
     end

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -188,8 +188,7 @@ function _classify_conflict(
     return error(
         "findMUS failed to compute a conflict: ",
         failure,
-        ". If findMUS timed out, raise the limit with `MOI.TimeLimitSec`; ",
-        "otherwise see the README for findMUS setup.\n",
+        ". If findMUS timed out, raise the limit with `MOI.TimeLimitSec`.\n",
         strip(string(errors, "\n", output)),
     )
 end
@@ -218,6 +217,9 @@ variable declarations, so a bound is never reported `IN_CONFLICT`. The reported
 conflict is guaranteed minimal; on timeout no conflict is reported rather than a
 possibly non-minimal one. Conflict analysis uses the Chuffed subsolver and is
 bounded by [`MOI.TimeLimitSec`](@ref) (default 60 seconds).
+
+See also [`MOI.ConflictStatus`](@ref) and
+[`MOI.ConstraintConflictStatus`](@ref).
 """
 function MOI.compute_conflict!(dest::Optimizer)
     msc = _findmus_msc()

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -1,0 +1,229 @@
+# Copyright (c) 2022 MiniZinc.jl contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+# Conflict (IIS) support via findMUS.
+#
+# findMUS (https://gitlab.com/minizinc/FindMUS) is a Minimal Unsatisfiable Subset
+# tool that ships as a MiniZinc pseudo-solver: it is invoked as
+# `minizinc --solver findMUS <model.mzn>` and, given an unsatisfiable model,
+# reports a minimal subset of constraints whose conjunction is unsatisfiable.
+#
+# We make each MOI constraint individually identifiable by stamping it with a
+# unique string annotation in `write.jl` (`constraint (..) :: "c<k>";`). findMUS
+# surfaces that string as the constraint's `expression_name` in its
+# `--output-json` report, which we map back to the originating `ConstraintIndex`.
+
+# Locate the findMUS solver configuration (`findmus.msc`). During development,
+# set `JULIA_FINDMUS_MSC` to the absolute path of a built `findmus.msc`. Returns
+# `nothing` when findMUS is unavailable.
+function _findmus_msc()
+    msc = get(ENV, "JULIA_FINDMUS_MSC", nothing)
+    if msc !== nothing && isfile(msc)
+        return msc
+    end
+    return nothing
+end
+
+# Directories to expose to the MiniZinc driver via `MZN_SOLVER_PATH` so it can
+# resolve both findMUS itself and the Chuffed subsolver it shells out to.
+function _findmus_solver_path(msc::AbstractString)
+    sep = Sys.iswindows() ? ';' : ':'
+    dirs = String[dirname(abspath(msc))]
+    chuffed = Chuffed()
+    if chuffed !== nothing
+        push!(dirs, dirname(chuffed))
+    end
+    existing = get(ENV, "MZN_SOLVER_PATH", "")
+    if !isempty(existing)
+        push!(dirs, existing)
+    end
+    return join(dirs, sep)
+end
+
+# Run findMUS on the (annotated) inner model. Returns
+# `(stdout, stderr, failure, tokens)` where `failure` is `nothing` on a clean run
+# or a human-readable reason otherwise, and `tokens` is the
+# `ConstraintIndex -> token` table produced by the annotated write.
+function _run_findmus(dest::Optimizer, msc::AbstractString)
+    dir = mktempdir()
+    filename = joinpath(dir, "model.mzn")
+    open(io -> write(io, dest.inner), filename, "w")
+    tokens = get(
+        dest.inner.ext,
+        :conflict_tokens,
+        Dict{MOI.ConstraintIndex,String}(),
+    )
+    overall_ms = round(Int, 1_000 * something(dest.time_limit_sec, 60.0))
+    sub_ms = clamp(div(overall_ms, 2), 1_000, 30_000)
+    solver_path = _findmus_solver_path(msc)
+    out_file = joinpath(dir, "stdout.txt")
+    err_file = joinpath(dir, "stderr.txt")
+    killed = Ref(false)
+    # `--named-only` scopes the search to our annotated constraints; `-g
+    # --soft-defines` keep bound/functional constraints from being absorbed into
+    # variable domains (otherwise they vanish from the MUS); `--no-leftover`
+    # suppresses any non-minimal candidate emitted on timeout, so any reported
+    # MUS is guaranteed minimal.
+    failure = try
+        _minizinc_exe() do exe
+            cmd = `$(exe) --solver $(msc) --named-only -g --soft-defines --paramset mzn --output-json -n 1 -t $(overall_ms) --no-leftover --subsolver org.chuffed.chuffed --subsolver-timelimit $(sub_ms) $(filename)`
+            cmd = addenv(cmd, "MZN_SOLVER_PATH" => solver_path)
+            proc = run(
+                pipeline(cmd; stdout = out_file, stderr = err_file);
+                wait = false,
+            )
+            # findMUS's own `-t` should fire first; this backstops a hung process.
+            timer = Timer(overall_ms / 1_000 + 30.0) do _t
+                if process_running(proc)
+                    killed[] = true
+                    kill(proc)
+                end
+            end
+            try
+                wait(proc)
+            finally
+                close(timer)
+            end
+            if killed[]
+                return "findMUS exceeded the wall-clock limit and was terminated"
+            elseif !success(proc)
+                return "findMUS exited with a non-zero status"
+            end
+            return nothing
+        end
+    catch err
+        err isa InterruptException && rethrow(err)
+        "findMUS could not be run ($(sprint(showerror, err)))"
+    end
+    output = isfile(out_file) ? read(out_file, String) : ""
+    errors = isfile(err_file) ? read(err_file, String) : ""
+    return output, errors, failure, tokens
+end
+
+# Collect the `expression_name` tokens findMUS reports inside its
+# `%%%mzn-json-start … %%%mzn-json-end` block, keeping only tokens we emitted.
+# This relies on findMUS pretty-printing one JSON field per line
+# (`lib/Types.cpp::getJSONSummary`) and on `-n 1` + `--no-leftover` yielding at
+# most one block; a switch to compact JSON output upstream would break this
+# line-based scan.
+function _parse_findmus_tokens(output::AbstractString, known::Set{String})
+    found = Set{String}()
+    in_block = false
+    for line in eachline(IOBuffer(output))
+        if occursin("%%%mzn-json-start", line)
+            in_block = true
+        elseif occursin("%%%mzn-json-end", line)
+            in_block = false
+        elseif in_block
+            m = match(r"\"expression_name\"\s*:\s*\"([^\"]*)\"", line)
+            if m !== nothing && m[1] in known
+                push!(found, m[1])
+            end
+        end
+    end
+    return found
+end
+
+"""
+    MOI.compute_conflict!(model::Optimizer)
+
+Compute a minimal conflicting subset of constraints (an Irreducible Infeasible
+Subset) for an infeasible model using findMUS, and record it for
+[`MOI.ConstraintConflictStatus`](@ref). Call after `optimize!` returns
+`INFEASIBLE`.
+
+The outcome is reported through [`MOI.ConflictStatus`](@ref):
+- `CONFLICT_FOUND` — a minimal conflict was found; its members read
+  `IN_CONFLICT` from `ConstraintConflictStatus`.
+- `NO_CONFLICT_FOUND` — no conflict could be attributed to the model's
+  constraints (the conflict involves only variable bounds, lies outside the
+  model, or could not be isolated in the time limit). This does **not** assert
+  the model is feasible.
+
+findMUS must be available: set the `JULIA_FINDMUS_MSC` environment variable to a
+built `findmus.msc` (a future `FindMUS_jll` dependency can provide it). If it is
+absent, an `ArgumentError` naming `compute_conflict!` is thrown so callers can
+tell a missing capability apart from a failed computation; a genuine findMUS
+failure throws an `ErrorException`.
+
+Conflicts cover modeling constraints only: MiniZinc folds variable bounds into
+variable declarations, so a bound is never reported `IN_CONFLICT`. The reported
+conflict is guaranteed minimal; on timeout no conflict is reported rather than a
+possibly non-minimal one. Conflict analysis uses the Chuffed subsolver and is
+bounded by [`MOI.TimeLimitSec`](@ref) (default 60 seconds).
+"""
+function MOI.compute_conflict!(dest::Optimizer)
+    msc = _findmus_msc()
+    if msc === nothing
+        throw(
+            ArgumentError(
+                "`compute_conflict!` requires findMUS, which is not available. " *
+                "Set the `JULIA_FINDMUS_MSC` environment variable to a built " *
+                "`findmus.msc` (a `FindMUS_jll` dependency can provide this).",
+            ),
+        )
+    end
+    empty!(dest.conflict_constraints)
+    dest.conflict_status = MOI.COMPUTE_CONFLICT_NOT_CALLED
+    dest.inner.ext[:conflict_annotate] = true
+    output, errors, failure, tokens = try
+        _run_findmus(dest, msc)
+    finally
+        delete!(dest.inner.ext, :conflict_annotate)
+        delete!(dest.inner.ext, :conflict_tokens)
+    end
+    # A reported MUS is authoritative and minimal (`--no-leftover`), so map its
+    # tokens to constraints first and trust it even if the process later exited
+    # non-zero.
+    conflicted = _parse_findmus_tokens(output, Set(values(tokens)))
+    for (ci, token) in tokens
+        if token in conflicted
+            push!(dest.conflict_constraints, ci)
+        end
+    end
+    if !isempty(dest.conflict_constraints)
+        dest.conflict_status = MOI.CONFLICT_FOUND
+        return
+    end
+    # No attributable MUS. findMUS reaches this cleanly for a satisfiable
+    # foreground, for a conflict that lies entirely in unnamed/background
+    # constraints ("Background is not satisfiable"), and for a timeout whose
+    # non-minimal leftover `--no-leftover` suppressed. The MiniZinc driver
+    # currently returns success for all of these; we additionally recognise
+    # findMUS's own messages so the result is robust to a driver that propagates
+    # findMUS's (non-zero) exit. Report NO_CONFLICT_FOUND — never
+    # NO_CONFLICT_EXISTS, which would falsely assert the model is feasible.
+    benign =
+        occursin("Model is Satisfiable", errors) ||
+        occursin("Background is not satisfiable", errors)
+    if failure === nothing || benign
+        dest.conflict_status = MOI.NO_CONFLICT_FOUND
+        return
+    end
+    return error(
+        "findMUS failed to compute a conflict: ",
+        failure,
+        ".\n",
+        strip(string(errors, "\n", output)),
+    )
+end
+
+MOI.get(model::Optimizer, ::MOI.ConflictStatus) = model.conflict_status
+
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.ConstraintConflictStatus,
+    ci::MOI.ConstraintIndex,
+)
+    if model.conflict_status == MOI.COMPUTE_CONFLICT_NOT_CALLED
+        throw(
+            MOI.GetAttributeNotAllowed(attr, "Call `compute_conflict!` first."),
+        )
+    end
+    if ci in model.conflict_constraints
+        return MOI.IN_CONFLICT
+    end
+    return MOI.NOT_IN_CONFLICT
+end

--- a/src/compute_conflict.jl
+++ b/src/compute_conflict.jl
@@ -19,7 +19,11 @@
 # it; `JULIA_FINDMUS_MSC` overrides that with a locally built config (the failure
 # test points it at a config whose binary is missing).
 function _findmus_msc()
-    return get(ENV, "JULIA_FINDMUS_MSC", FindMUS_jll.findmus_msc)
+    # `abspath` so the config still resolves after the findMUS subprocess is run
+    # with its working directory set to the temp dir (a relative
+    # `JULIA_FINDMUS_MSC` would otherwise break); `FindMUS_jll.findmus_msc` is
+    # already absolute.
+    return abspath(get(ENV, "JULIA_FINDMUS_MSC", FindMUS_jll.findmus_msc))
 end
 
 # Directories to expose to the MiniZinc driver via `MZN_SOLVER_PATH` so it can
@@ -41,8 +45,8 @@ end
 # The findMUS invocation. `--named-only` scopes the search to our annotated
 # constraints; `-g --soft-defines` keep bound/functional constraints from being
 # absorbed into variable domains (otherwise they vanish from the MUS);
-# `--no-leftover` suppresses any non-minimal candidate emitted on timeout, so any
-# reported MUS is guaranteed minimal; `--paramset mzn` selects MiniZinc-level
+# `--no-leftover` suppresses the non-minimal candidate findMUS would otherwise
+# emit if the overall search times out; `--paramset mzn` selects MiniZinc-level
 # output so each member's annotation surfaces as its `expression_name`. Kept a
 # pure builder so the exact flag set stays unit-testable without findMUS present.
 function _findmus_cmd(
@@ -80,9 +84,18 @@ function _run_findmus(dest::Optimizer, msc::AbstractString)
     killed = Ref(false)
     failure = try
         _minizinc_exe() do exe
-            cmd = addenv(
-                _findmus_cmd(exe, msc, filename, overall_ms, sub_ms),
-                "MZN_SOLVER_PATH" => solver_path,
+            # Run in `dir` so findMUS's failure artifact lands in the temp
+            # directory rather than the caller's working directory: when a
+            # subsolver check errors (e.g. a float model, which the Chuffed
+            # subsolver cannot handle) findMUS dumps a
+            # `FINDMUS_failed_subproblem.fzn` into its working directory.
+            # `filename`, `out_file`, and `err_file` are already absolute.
+            cmd = Cmd(
+                addenv(
+                    _findmus_cmd(exe, msc, filename, overall_ms, sub_ms),
+                    "MZN_SOLVER_PATH" => solver_path,
+                );
+                dir = dir,
             )
             proc = run(
                 pipeline(cmd; stdout = out_file, stderr = err_file);
@@ -92,8 +105,9 @@ function _run_findmus(dest::Optimizer, msc::AbstractString)
             # `kill` targets the `minizinc` process; any findMUS/Chuffed children
             # are independently bounded by `-t` and `--subsolver-timelimit`, so a
             # driver-only kill cannot leave an unbounded process behind. The output
-            # captured below is only trusted when a complete MUS block is present,
-            # which this killed path never produces.
+            # captured below is only trusted when a complete MUS block is present;
+            # a kill mid-report cannot fabricate one (`_parse_findmus_tokens`
+            # ignores an unterminated block).
             timer = Timer(overall_ms / 1_000 + 30.0) do _t
                 if process_running(proc)
                     killed[] = true
@@ -159,10 +173,11 @@ end
 # conflicting constraints. Kept free of I/O (the subprocess lives in
 # `_run_findmus`) so it can be unit-tested with canned findMUS reports.
 #
-# A reported MUS is authoritative and minimal (`--no-leftover`), so its tokens
-# are mapped to constraints first and trusted even if the process later exited
-# non-zero. Otherwise the outcome turns on findMUS's own messages (recognised so
-# the result is robust to a driver that propagates findMUS's non-zero exit):
+# A reported MUS is authoritative (its members form an infeasible set), so its
+# tokens are mapped to constraints first and trusted even if the process later
+# exited non-zero. Otherwise the outcome turns on findMUS's own messages
+# (recognised so the result is robust to a driver that propagates findMUS's
+# non-zero exit):
 # "Model is Satisfiable" proves the model feasible (NO_CONFLICT_EXISTS), while a
 # background-only conflict ("Background is not satisfiable") or a clean exit that
 # isolated no MUS (e.g. a timeout whose non-minimal leftover `--no-leftover`
@@ -235,9 +250,12 @@ surface it to the user.
 
 Conflicts cover modeling constraints only: MiniZinc folds variable bounds into
 variable declarations, so a bound is never reported `IN_CONFLICT`. The reported
-conflict is guaranteed minimal; on timeout no conflict is reported rather than a
-possibly non-minimal one. Conflict analysis uses the Chuffed subsolver and is
-bounded by [`MOI.TimeLimitSec`](@ref) (default 60 seconds).
+conflict is the minimal set findMUS isolates; on timeout no conflict is reported
+rather than a possibly non-minimal one. Conflict analysis always uses the Chuffed
+subsolver, regardless of the solver the `Optimizer` was constructed with (so a
+model outside Chuffed's support, for example one with floating-point variables,
+reports `NO_CONFLICT_FOUND`), and is bounded by [`MOI.TimeLimitSec`](@ref)
+(default 60 seconds).
 
 See also [`MOI.ConflictStatus`](@ref) and
 [`MOI.ConstraintConflictStatus`](@ref).

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -33,6 +33,12 @@ mutable struct Optimizer{T} <: MOI.AbstractOptimizer
     options::Dict{String,Any}
     time_limit_sec::Union{Nothing,Float64}
     solve_time_sec::Float64
+    # Conflict (IIS) state, populated by `compute_conflict!`. `conflict_status`
+    # tracks whether a conflict computation ran and its outcome;
+    # `conflict_constraints` holds the inner `ConstraintIndex`es that findMUS
+    # reported as part of a minimal unsatisfiable subset.
+    conflict_status::MOI.ConflictStatusCode
+    conflict_constraints::Set{MOI.ConstraintIndex}
     function Optimizer{T}(solver::String) where {T}
         if solver == "chuffed"
             solver = Chuffed()
@@ -49,6 +55,8 @@ mutable struct Optimizer{T} <: MOI.AbstractOptimizer
             options,
             nothing,
             NaN,
+            MOI.COMPUTE_CONFLICT_NOT_CALLED,
+            Set{MOI.ConstraintIndex}(),
         )
     end
 end
@@ -136,6 +144,8 @@ function MOI.empty!(model::Optimizer{T}) where {T}
     model.primal_objective = zero(T)
     empty!(model.primal_solutions)
     model.solve_time_sec = NaN
+    model.conflict_status = MOI.COMPUTE_CONFLICT_NOT_CALLED
+    empty!(model.conflict_constraints)
     return
 end
 

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -225,6 +225,9 @@ function MOI.optimize!(dest::Optimizer{T}, src::MOI.ModelLike) where {T}
     time_start = time()
     MOI.empty!(dest.inner)
     empty!(dest.primal_solutions)
+    # A re-solve invalidates any conflict computed for the previous model.
+    dest.conflict_status = MOI.COMPUTE_CONFLICT_NOT_CALLED
+    empty!(dest.conflict_constraints)
     index_map = MOI.copy_to(dest.inner, src)
     ret = _run_minizinc(dest)
     if !isempty(ret)

--- a/src/write.jl
+++ b/src/write.jl
@@ -544,8 +544,9 @@ function _write_annotated_constraint(
     _write_constraint(buf, predicates, variables, f, s)
     line = String(take!(buf))
     # The splice depends on the one-`constraint`-per-overload invariant above.
-    # Check it explicitly rather than with `@assert`, which is elided under
-    # `--check-bounds=no`; a violation would otherwise silently corrupt a token.
+    # Check it explicitly rather than with `@assert`, which Julia may disable at
+    # higher optimization levels; a violation would otherwise silently corrupt a
+    # token.
     if !startswith(line, "constraint ") || !endswith(line, ";\n")
         error("cannot annotate constraint output: ", repr(line))
     end

--- a/src/write.jl
+++ b/src/write.jl
@@ -525,6 +525,35 @@ function _write_ifelse(
     return
 end
 
+# Re-emit a single `constraint <body>;` line with a string-literal annotation
+# carrying `token`, e.g. `constraint (<body>) :: "c3";`. A MUS tool (findMUS)
+# surfaces the literal as the constraint's `expression_name`, which lets
+# `compute_conflict.jl` map each conflict member back to a MOI `ConstraintIndex`.
+# Every `_write_constraint` method emits exactly one `constraint ...;` statement,
+# so capturing it and splicing the annotation in is sufficient and keeps the
+# annotation logic out of the ~15 overloads.
+function _write_annotated_constraint(
+    io::IO,
+    predicates::Set,
+    variables::Dict,
+    f,
+    s,
+    token::AbstractString,
+)
+    buf = IOBuffer()
+    _write_constraint(buf, predicates, variables, f, s)
+    line = String(take!(buf))
+    # The splice depends on the one-`constraint`-per-overload invariant above.
+    # Check it explicitly rather than with `@assert`, which is elided under
+    # `--check-bounds=no`; a violation would otherwise silently corrupt a token.
+    if !startswith(line, "constraint ") || !endswith(line, ";\n")
+        error("cannot annotate constraint output: ", repr(line))
+    end
+    body = chop(line; head = length("constraint "), tail = 2)
+    println(io, "constraint (", body, ") :: \"", token, "\";")
+    return
+end
+
 function Base.write(io::IO, model::Model{T}) where {T}
     rs = [
         s -> match(r"^[^a-zA-Z]", s) !== nothing ? "x" * s : s,
@@ -533,6 +562,13 @@ function Base.write(io::IO, model::Model{T}) where {T}
     MOI.FileFormats.create_unique_variable_names(model, false, rs)
     variables = _write_variables(io, model)
     predicates = Set{String}()
+    # Opt-in (set by `compute_conflict.jl`): stamp each emitted constraint with a
+    # globally-unique string token so findMUS can report which MOI constraint each
+    # MUS member maps back to. The `ci -> token` table is stashed in `model.ext`
+    # for `compute_conflict!` to read; a running counter guarantees uniqueness
+    # across `(F, S)` types (MOI only promises `ci.value` uniqueness within one).
+    annotate = get(model.ext, :conflict_annotate, false)::Bool
+    tokens = Dict{MOI.ConstraintIndex,String}()
     for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
         if F == MOI.VariableIndex
             continue
@@ -540,7 +576,20 @@ function Base.write(io::IO, model::Model{T}) where {T}
         for ci in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
             f = MOI.get(model, MOI.ConstraintFunction(), ci)
             s = MOI.get(model, MOI.ConstraintSet(), ci)
-            _write_constraint(io, predicates, variables, f, s)
+            if annotate
+                token = string("c", length(tokens) + 1)
+                tokens[ci] = token
+                _write_annotated_constraint(
+                    io,
+                    predicates,
+                    variables,
+                    f,
+                    s,
+                    token,
+                )
+            else
+                _write_constraint(io, predicates, variables, f, s)
+            end
         end
     end
     sense = MOI.get(model, MOI.ObjectiveSense())
@@ -556,6 +605,9 @@ function Base.write(io::IO, model::Model{T}) where {T}
     end
     for p in predicates
         println(io, "include \"", p, ".mzn\";")
+    end
+    if annotate
+        model.ext[:conflict_tokens] = tokens
     end
     return
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2194,6 +2194,14 @@ function test_parse_findmus_tokens()
     @test isempty(MiniZinc._parse_findmus_tokens(foreign, known))
     # No block markers -> nothing found.
     @test isempty(MiniZinc._parse_findmus_tokens("no markers here", known))
+    # Two blocks union their members (documented behaviour of the scanner).
+    two =
+        "%%%mzn-json-start\n{\"expression_name\": \"c1\"}\n%%%mzn-json-end\n" *
+        "%%%mzn-json-start\n{\"expression_name\": \"c2\"}\n%%%mzn-json-end\n"
+    @test MiniZinc._parse_findmus_tokens(two, known) == Set(["c1", "c2"])
+    # A stray end marker before any start is a no-op (the flag is a boolean).
+    stray = "%%%mzn-json-end\n{\"expression_name\": \"c1\"}\n"
+    @test isempty(MiniZinc._parse_findmus_tokens(stray, known))
     return
 end
 
@@ -2271,6 +2279,12 @@ function test_classify_conflict()
             tokens,
         ),
     )
+    # A clean findMUS exit (failure === nothing) with annotatable constraints
+    # but no attributable MUS and no benign marker is NO_CONFLICT_FOUND, not an
+    # error — the common "no MUS could be isolated" outcome.
+    status, conflict = MiniZinc._classify_conflict("", "", nothing, tokens)
+    @test status == MOI.NO_CONFLICT_FOUND
+    @test isempty(conflict)
     # An empty token table (a model with no annotatable constraints, e.g. only
     # variable bounds, which fold into declarations) can never yield
     # CONFLICT_FOUND, whatever the report contains.
@@ -2330,6 +2344,18 @@ function test_compute_conflict_found()
           MOI.IN_CONFLICT
     @test MOI.get(opt, MOI.ConstraintConflictStatus(), index_map[c3]) ==
           MOI.NOT_IN_CONFLICT
+    # Re-solving the same optimizer must clear the stale conflict; otherwise a
+    # later `ConflictStatus` query would report the previous model's conflict.
+    feasible = MiniZinc.Model{Int}()
+    v = MOI.add_variable(feasible)
+    MOI.set(feasible, MOI.VariableName(), v, "v")
+    MOI.add_constraint(feasible, v, MOI.Interval(1, 10))
+    MOI.optimize!(opt, feasible)
+    @test MOI.get(opt, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
+    @test_throws(
+        MOI.GetAttributeNotAllowed{MOI.ConstraintConflictStatus},
+        MOI.get(opt, MOI.ConstraintConflictStatus(), index_map[c1]),
+    )
     return
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2264,31 +2264,9 @@ function test_constraint_conflict_status_before_compute()
     return
 end
 
-# A missing findMUS reads as a capability gap (ArgumentError naming the
-# operation), not a computation failure. Always runnable; forces absence.
-function test_compute_conflict_unavailable()
-    withenv("JULIA_FINDMUS_MSC" => nothing) do
-        if MiniZinc._findmus_msc() !== nothing
-            return  # FindMUS_jll installed; absence cannot be simulated here.
-        end
-        opt, _, _ = _conflict_model()
-        err = try
-            MOI.compute_conflict!(opt)
-            nothing
-        catch e
-            e
-        end
-        @test err isa ArgumentError
-        # `&&` short-circuits so a non-throw (`err === nothing`) fails cleanly
-        # rather than erroring on `nothing.msg`.
-        @test err isa ArgumentError && occursin("compute_conflict!", err.msg)
-    end
-    return
-end
-
 # A genuine findMUS failure (here a solver config whose binary is missing)
-# surfaces as an ErrorException, distinct from the missing-capability
-# ArgumentError. Needs only the MiniZinc driver, so it runs without findMUS.
+# surfaces as an ErrorException. The bogus config is supplied via
+# `JULIA_FINDMUS_MSC`, so the test needs only the MiniZinc driver, not findMUS.
 function test_compute_conflict_failure()
     dir = mktempdir()
     msc = joinpath(dir, "findmus.msc")
@@ -2310,10 +2288,6 @@ function test_compute_conflict_failure()
 end
 
 function test_compute_conflict_found()
-    if MiniZinc._findmus_msc() === nothing
-        @info "Skipping test_compute_conflict_found: set JULIA_FINDMUS_MSC to run."
-        return
-    end
     opt, index_map, (c1, c2, c3) = _conflict_model()
     @test MOI.get(opt, MOI.TerminationStatus()) == MOI.INFEASIBLE
     MOI.compute_conflict!(opt)
@@ -2330,10 +2304,6 @@ end
 # A feasible model has no conflict to attribute -> NO_CONFLICT_FOUND, never
 # NO_CONFLICT_EXISTS (which would falsely assert feasibility-by-proof).
 function test_compute_conflict_feasible()
-    if MiniZinc._findmus_msc() === nothing
-        @info "Skipping test_compute_conflict_feasible: set JULIA_FINDMUS_MSC to run."
-        return
-    end
     src = MiniZinc.Model{Int}()
     x = MOI.add_variable(src)
     y = MOI.add_variable(src)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2041,6 +2041,167 @@ function test_example_sudoku()
     return
 end
 
+# --- Conflict (IIS) support via findMUS -----------------------------------------
+
+# An infeasible CP model whose conflict lies in two multi-variable constraints
+# (c1, c2) so they are emitted as annotatable `constraint` lines; c3 is
+# satisfiable and unrelated. Returns the optimizer, the src->inner index map, and
+# the source constraint indices.
+function _conflict_model()
+    src = MiniZinc.Model{Int}()
+    x = MOI.add_variable(src)
+    y = MOI.add_variable(src)
+    z = MOI.add_variable(src)
+    for (v, n) in ((x, "x"), (y, "y"), (z, "z"))
+        MOI.set(src, MOI.VariableName(), v, n)
+        MOI.add_constraint(src, v, MOI.Interval(1, 10))
+    end
+    xy = MOI.ScalarAffineFunction(
+        [MOI.ScalarAffineTerm(1, x), MOI.ScalarAffineTerm(1, y)],
+        0,
+    )
+    zx = MOI.ScalarAffineFunction(
+        [MOI.ScalarAffineTerm(1, z), MOI.ScalarAffineTerm(-1, x)],
+        0,
+    )
+    c1 = MOI.add_constraint(src, xy, MOI.GreaterThan(18)) # x + y >= 18
+    c2 = MOI.add_constraint(src, xy, MOI.LessThan(5))     # x + y <= 5
+    c3 = MOI.add_constraint(src, zx, MOI.GreaterThan(0))  # z >= x (unrelated)
+    opt = MiniZinc.Optimizer{Int}("chuffed")
+    index_map, _ = MOI.optimize!(opt, src)
+    return opt, index_map, (c1, c2, c3)
+end
+
+# Annotation is a pure `write.jl` feature and needs no findMUS to test.
+function test_write_conflict_annotations()
+    model = MiniZinc.Model{Int}()
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+    MOI.set(model, MOI.VariableName(), x, "x")
+    MOI.set(model, MOI.VariableName(), y, "y")
+    MOI.add_constraint(model, x, MOI.Interval(1, 10))
+    MOI.add_constraint(model, y, MOI.Interval(1, 10))
+    f = MOI.ScalarAffineFunction(
+        [MOI.ScalarAffineTerm(1, x), MOI.ScalarAffineTerm(1, y)],
+        0,
+    )
+    c1 = MOI.add_constraint(model, f, MOI.GreaterThan(18))
+    c2 = MOI.add_constraint(model, f, MOI.LessThan(5))
+    # Without the opt-in flag, output is unchanged (no annotations).
+    @test !occursin("::", sprint(write, model))
+    # With it, every emitted constraint carries a unique string token, and the
+    # ci -> token table is exposed via `model.ext`.
+    model.ext[:conflict_annotate] = true
+    annotated = sprint(write, model)
+    @test occursin("\"c1\"", annotated)
+    @test occursin("\"c2\"", annotated)
+    tokens = model.ext[:conflict_tokens]
+    @test length(tokens) == 2
+    @test Set(values(tokens)) == Set(["c1", "c2"])
+    @test tokens[c1] != tokens[c2]
+    return
+end
+
+# Querying participation before computing the conflict is an error.
+function test_constraint_conflict_status_before_compute()
+    opt, index_map, (c1, _, _) = _conflict_model()
+    @test MOI.get(opt, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
+    @test_throws(
+        MOI.GetAttributeNotAllowed{MOI.ConstraintConflictStatus},
+        MOI.get(opt, MOI.ConstraintConflictStatus(), index_map[c1]),
+    )
+    return
+end
+
+# A missing findMUS reads as a capability gap (ArgumentError naming the
+# operation), not a computation failure. Always runnable; forces absence.
+function test_compute_conflict_unavailable()
+    withenv("JULIA_FINDMUS_MSC" => nothing) do
+        if MiniZinc._findmus_msc() !== nothing
+            return  # FindMUS_jll installed; absence cannot be simulated here.
+        end
+        opt, _, _ = _conflict_model()
+        err = try
+            MOI.compute_conflict!(opt)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        # `&&` short-circuits so a non-throw (`err === nothing`) fails cleanly
+        # rather than erroring on `nothing.msg`.
+        @test err isa ArgumentError && occursin("compute_conflict!", err.msg)
+    end
+    return
+end
+
+# A genuine findMUS failure (here a solver config whose binary is missing)
+# surfaces as an ErrorException, distinct from the missing-capability
+# ArgumentError. Needs only the MiniZinc driver, so it runs without findMUS.
+function test_compute_conflict_failure()
+    dir = mktempdir()
+    msc = joinpath(dir, "findmus.msc")
+    write(
+        msc,
+        string(
+            "{\"id\":\"org.minizinc.findmus\",\"name\":\"findMUS\",",
+            "\"executable\":\"",
+            joinpath(dir, "missing_binary"),
+            "\",",
+            "\"version\":\"0.7.0\",\"supportsMzn\":true}",
+        ),
+    )
+    withenv("JULIA_FINDMUS_MSC" => msc) do
+        opt, _, _ = _conflict_model()
+        @test_throws ErrorException MOI.compute_conflict!(opt)
+    end
+    return
+end
+
+function test_compute_conflict_found()
+    if MiniZinc._findmus_msc() === nothing
+        @info "Skipping test_compute_conflict_found: set JULIA_FINDMUS_MSC to run."
+        return
+    end
+    opt, index_map, (c1, c2, c3) = _conflict_model()
+    @test MOI.get(opt, MOI.TerminationStatus()) == MOI.INFEASIBLE
+    MOI.compute_conflict!(opt)
+    @test MOI.get(opt, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
+    @test MOI.get(opt, MOI.ConstraintConflictStatus(), index_map[c1]) ==
+          MOI.IN_CONFLICT
+    @test MOI.get(opt, MOI.ConstraintConflictStatus(), index_map[c2]) ==
+          MOI.IN_CONFLICT
+    @test MOI.get(opt, MOI.ConstraintConflictStatus(), index_map[c3]) ==
+          MOI.NOT_IN_CONFLICT
+    return
+end
+
+# A feasible model has no conflict to attribute -> NO_CONFLICT_FOUND, never
+# NO_CONFLICT_EXISTS (which would falsely assert feasibility-by-proof).
+function test_compute_conflict_feasible()
+    if MiniZinc._findmus_msc() === nothing
+        @info "Skipping test_compute_conflict_feasible: set JULIA_FINDMUS_MSC to run."
+        return
+    end
+    src = MiniZinc.Model{Int}()
+    x = MOI.add_variable(src)
+    y = MOI.add_variable(src)
+    for (v, n) in ((x, "x"), (y, "y"))
+        MOI.set(src, MOI.VariableName(), v, n)
+        MOI.add_constraint(src, v, MOI.Interval(1, 10))
+    end
+    f = MOI.ScalarAffineFunction(
+        [MOI.ScalarAffineTerm(1, x), MOI.ScalarAffineTerm(1, y)],
+        0,
+    )
+    MOI.add_constraint(src, f, MOI.GreaterThan(5))
+    opt = MiniZinc.Optimizer{Int}("chuffed")
+    MOI.optimize!(opt, src)
+    MOI.compute_conflict!(opt)
+    @test MOI.get(opt, MOI.ConflictStatus()) == MOI.NO_CONFLICT_FOUND
+    return
+end
+
 end
 
 TestMiniZinc.runtests()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1202,6 +1202,38 @@ function test_moi_tests()
     return
 end
 
+function test_moi_conflict_tests()
+    model = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.Model{Int}(),
+        MiniZinc.Optimizer{Int}("chuffed"),
+    )
+    config = MOI.Test.Config(Int)
+    MOI.Test.runtests(
+        model,
+        config;
+        include = String["test_solve_conflict_"],
+        exclude = Union{String,Regex}[
+            # Each of these asserts that a variable bound or integrality is itself
+            # IN_CONFLICT. MiniZinc folds variable bounds and integrality into the
+            # variable declaration, so they have no constraint line to annotate and
+            # are never reported IN_CONFLICT (such conflicts surface as
+            # NO_CONFLICT_FOUND). `affine_affine`, `EqualTo`, and `NOT_IN_CONFLICT`
+            # fail on their `x >= 0` / `y >= 0` bound assertions, not the affine
+            # ones; `zeroone`/`zeroone_2` hinge on a `ZeroOne` integrality.
+            "test_solve_conflict_bound_bound",
+            "test_solve_conflict_invalid_interval",
+            "test_solve_conflict_affine_affine",
+            "test_solve_conflict_EqualTo",
+            "test_solve_conflict_NOT_IN_CONFLICT",
+            r"test_solve_conflict_zeroone",  # zeroone and zeroone_2
+            # findMUS proves unsatisfiability, not feasibility, so a feasible model
+            # yields NO_CONFLICT_FOUND, not the NO_CONFLICT_EXISTS asserted here.
+            "test_solve_conflict_feasible",
+        ],
+    )
+    return
+end
+
 function test_model_filename()
     model = MOI.Utilities.Model{Int}()
     x, x_int = MOI.add_constrained_variable(model, MOI.Integer())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2200,7 +2200,7 @@ function test_parse_findmus_tokens()
     stray = "%%%mzn-json-end\n{\"expression_name\": \"c1\"}\n"
     @test isempty(MiniZinc._parse_findmus_tokens(stray, known))
     # A truncated block (start with no closing end marker, e.g. findMUS was
-    # killed mid-report) commits nothing: partial output is not a conflict.
+    # interrupted mid-report) commits nothing: partial output is not a conflict.
     truncated = "%%%mzn-json-start\n{\"expression_name\": \"c1\"}\n"
     @test isempty(MiniZinc._parse_findmus_tokens(truncated, known))
     return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2242,7 +2242,10 @@ end
 function test_findmus_solver_path()
     sep = Sys.iswindows() ? ';' : ':'
     msc = joinpath(@__DIR__, "findmus.msc")
-    base = withenv(() -> MiniZinc._findmus_solver_path(msc), "MZN_SOLVER_PATH" => nothing)
+    base = withenv(
+        () -> MiniZinc._findmus_solver_path(msc),
+        "MZN_SOLVER_PATH" => nothing,
+    )
     @test dirname(abspath(msc)) in split(base, sep)
     @test !("/custom/solver/dir" in split(base, sep))
     extended = withenv(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2344,6 +2344,21 @@ function test_compute_conflict_found()
           MOI.IN_CONFLICT
     @test MOI.get(opt, MOI.ConstraintConflictStatus(), index_map[c3]) ==
           MOI.NOT_IN_CONFLICT
+    # Exactly one conflict is reported, so `ConflictCount` is 1 and an
+    # out-of-range conflict index or an invalid constraint errors rather than
+    # silently returning a status.
+    @test MOI.get(opt, MOI.ConflictCount()) == 1
+    @test_throws(
+        MOI.ConflictIndexBoundsError{MOI.ConstraintConflictStatus},
+        MOI.get(opt, MOI.ConstraintConflictStatus(2), index_map[c1]),
+    )
+    bad = MOI.ConstraintIndex{MOI.ScalarAffineFunction{Int},MOI.LessThan{Int}}(
+        987654,
+    )
+    @test_throws(
+        MOI.InvalidIndex,
+        MOI.get(opt, MOI.ConstraintConflictStatus(), bad),
+    )
     # Re-solving the same optimizer must clear the stale conflict; otherwise a
     # later `ConflictStatus` query would report the previous model's conflict.
     feasible = MiniZinc.Model{Int}()
@@ -2352,6 +2367,7 @@ function test_compute_conflict_found()
     MOI.add_constraint(feasible, v, MOI.Interval(1, 10))
     MOI.optimize!(opt, feasible)
     @test MOI.get(opt, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
+    @test MOI.get(opt, MOI.ConflictCount()) == 0
     @test_throws(
         MOI.GetAttributeNotAllowed{MOI.ConstraintConflictStatus},
         MOI.get(opt, MOI.ConstraintConflictStatus(), index_map[c1]),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2102,6 +2102,78 @@ function test_write_conflict_annotations()
     return
 end
 
+# The findMUS report parser keys off the `%%%mzn-json-*` block markers and the
+# `expression_name` field. Exercise it with canned reports (no findMUS needed).
+function test_parse_findmus_tokens()
+    known = Set(["c1", "c2", "c3"])
+    report = """
+    preamble
+    %%%mzn-json-start
+    { "expression_name" : "c1" },
+    { "expression_name" : "c2" }
+    %%%mzn-json-end
+    """
+    @test MiniZinc._parse_findmus_tokens(report, known) == Set(["c1", "c2"])
+    # An `expression_name` outside the JSON block is ignored.
+    @test isempty(
+        MiniZinc._parse_findmus_tokens("\"expression_name\" : \"c1\"", known),
+    )
+    # Tokens we did not emit are ignored even inside the block.
+    foreign = "%%%mzn-json-start\n{ \"expression_name\" : \"other\" }\n%%%mzn-json-end\n"
+    @test isempty(MiniZinc._parse_findmus_tokens(foreign, known))
+    # No block markers -> nothing found.
+    @test isempty(MiniZinc._parse_findmus_tokens("no markers here", known))
+    return
+end
+
+# `_classify_conflict` is the pure decision logic of `compute_conflict!`. Drive
+# its outcomes with canned findMUS output, again without needing findMUS.
+function test_classify_conflict()
+    F, S = MOI.ScalarAffineFunction{Int}, MOI.LessThan{Int}
+    ci(i) = MOI.ConstraintIndex{F,S}(i)
+    tokens = Dict{MOI.ConstraintIndex,String}(ci(1) => "c1", ci(2) => "c2")
+    mus = "%%%mzn-json-start\n{ \"expression_name\" : \"c2\" }\n%%%mzn-json-end\n"
+    # A reported MUS -> CONFLICT_FOUND with exactly its members, trusted even
+    # when the process also reports a non-zero exit.
+    status, conflict = MiniZinc._classify_conflict(
+        mus,
+        "",
+        "findMUS exited with a non-zero status",
+        tokens,
+    )
+    @test status == MOI.CONFLICT_FOUND
+    @test conflict == Set([ci(2)])
+    # Satisfiable foreground -> NO_CONFLICT_FOUND.
+    status, conflict = MiniZinc._classify_conflict(
+        "",
+        "Error: Model is Satisfiable",
+        nothing,
+        tokens,
+    )
+    @test status == MOI.NO_CONFLICT_FOUND
+    @test isempty(conflict)
+    # Background-unsat is benign even though findMUS exits non-zero.
+    status, _ = MiniZinc._classify_conflict(
+        "",
+        "Background is not satisfiable, exiting",
+        "findMUS exited with a non-zero status",
+        tokens,
+    )
+    @test status == MOI.NO_CONFLICT_FOUND
+    # A genuine failure (no MUS, no benign marker) is an error, not a silent
+    # NO_CONFLICT_FOUND.
+    @test_throws(
+        ErrorException,
+        MiniZinc._classify_conflict(
+            "",
+            "unexpected solver crash",
+            "findMUS exited with a non-zero status",
+            tokens,
+        ),
+    )
+    return
+end
+
 # Querying participation before computing the conflict is an error.
 function test_constraint_conflict_status_before_compute()
     opt, index_map, (c1, _, _) = _conflict_model()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2235,6 +2235,25 @@ function test_findmus_command()
     return
 end
 
+# `_findmus_solver_path` builds the `MZN_SOLVER_PATH` exposed to the driver. The
+# findMUS/Chuffed directories come from the environment, so just check that a
+# pre-existing `MZN_SOLVER_PATH` entry is preserved (and absent otherwise). No
+# findMUS needed: the function only manipulates path strings.
+function test_findmus_solver_path()
+    sep = Sys.iswindows() ? ';' : ':'
+    msc = joinpath(@__DIR__, "findmus.msc")
+    base = withenv(() -> MiniZinc._findmus_solver_path(msc), "MZN_SOLVER_PATH" => nothing)
+    @test dirname(abspath(msc)) in split(base, sep)
+    @test !("/custom/solver/dir" in split(base, sep))
+    extended = withenv(
+        () -> MiniZinc._findmus_solver_path(msc),
+        "MZN_SOLVER_PATH" => "/custom/solver/dir",
+    )
+    @test "/custom/solver/dir" in split(extended, sep)
+    @test dirname(abspath(msc)) in split(extended, sep)
+    return
+end
+
 # `_classify_conflict` is the pure decision logic of `compute_conflict!`. Drive
 # its outcomes with canned findMUS output, again without needing findMUS.
 function test_classify_conflict()
@@ -2377,8 +2396,9 @@ function test_compute_conflict_found()
     return
 end
 
-# A feasible model has no conflict to attribute -> NO_CONFLICT_FOUND, never
-# NO_CONFLICT_EXISTS (which would falsely assert feasibility-by-proof).
+# findMUS proves a feasible model satisfiable, a genuine feasibility proof, so
+# its conflict status is NO_CONFLICT_EXISTS (not NO_CONFLICT_FOUND, which is
+# reserved for "no conflict could be attributed" without such a proof).
 function test_compute_conflict_feasible()
     src = MiniZinc.Model{Int}()
     x = MOI.add_variable(src)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1226,9 +1226,6 @@ function test_moi_conflict_tests()
             "test_solve_conflict_EqualTo",
             "test_solve_conflict_NOT_IN_CONFLICT",
             r"test_solve_conflict_zeroone",  # zeroone and zeroone_2
-            # findMUS proves unsatisfiability, not feasibility, so a feasible model
-            # yields NO_CONFLICT_FOUND, not the NO_CONFLICT_EXISTS asserted here.
-            "test_solve_conflict_feasible",
         ],
     )
     return
@@ -2202,6 +2199,10 @@ function test_parse_findmus_tokens()
     # A stray end marker before any start is a no-op (the flag is a boolean).
     stray = "%%%mzn-json-end\n{\"expression_name\": \"c1\"}\n"
     @test isempty(MiniZinc._parse_findmus_tokens(stray, known))
+    # A truncated block (start with no closing end marker, e.g. findMUS was
+    # killed mid-report) commits nothing: partial output is not a conflict.
+    truncated = "%%%mzn-json-start\n{\"expression_name\": \"c1\"}\n"
+    @test isempty(MiniZinc._parse_findmus_tokens(truncated, known))
     return
 end
 
@@ -2251,14 +2252,15 @@ function test_classify_conflict()
     )
     @test status == MOI.CONFLICT_FOUND
     @test conflict == Set([ci(2)])
-    # Satisfiable foreground -> NO_CONFLICT_FOUND.
+    # findMUS proving the model satisfiable is a feasibility proof ->
+    # NO_CONFLICT_EXISTS.
     status, conflict = MiniZinc._classify_conflict(
         "",
         "Error: Model is Satisfiable",
         nothing,
         tokens,
     )
-    @test status == MOI.NO_CONFLICT_FOUND
+    @test status == MOI.NO_CONFLICT_EXISTS
     @test isempty(conflict)
     # Background-unsat is benign even though findMUS exits non-zero.
     status, _ = MiniZinc._classify_conflict(
@@ -2393,7 +2395,7 @@ function test_compute_conflict_feasible()
     opt = MiniZinc.Optimizer{Int}("chuffed")
     MOI.optimize!(opt, src)
     MOI.compute_conflict!(opt)
-    @test MOI.get(opt, MOI.ConflictStatus()) == MOI.NO_CONFLICT_FOUND
+    @test MOI.get(opt, MOI.ConflictStatus()) == MOI.NO_CONFLICT_EXISTS
     return
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2102,27 +2102,95 @@ function test_write_conflict_annotations()
     return
 end
 
+# The annotation splice must hold across every constraint shape, not only
+# `ScalarAffineFunction` — especially the global/nonlinear emitters whose
+# `_write_constraint` overloads build the line across multiple `print` calls.
+function test_write_conflict_annotations_shapes()
+    model = MiniZinc.Model{Int}()
+    x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
+    for i in 1:3
+        MOI.set(model, MOI.VariableName(), x[i], "x$i")
+    end
+    saf = MOI.ScalarAffineFunction(
+        [MOI.ScalarAffineTerm(1, x[1]), MOI.ScalarAffineTerm(1, x[2])],
+        0,
+    )
+    MOI.add_constraint(model, saf, MOI.LessThan(5))
+    MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(x),
+        MOI.Table([1 1 0; 0 1 1]),
+    )
+    nl = MOI.ScalarNonlinearFunction(:alldifferent, Any[x])
+    MOI.add_constraint(model, nl, MOI.EqualTo(1))
+    model.ext[:conflict_annotate] = true
+    annotated = sprint(write, model)
+    lines = filter(startswith("constraint "), split(annotated, '\n'))
+    # Affine, table (loop-built), and nonlinear-global lines are each wrapped
+    # and annotated with a well-formed token; none trips the splice guard.
+    @test length(lines) == 3
+    for line in lines
+        @test occursin(r"^constraint \(.*\) :: \"c\d+\";$", line)
+    end
+    @test length(model.ext[:conflict_tokens]) == 3
+    return
+end
+
 # The findMUS report parser keys off the `%%%mzn-json-*` block markers and the
 # `expression_name` field. Exercise it with canned reports (no findMUS needed).
 function test_parse_findmus_tokens()
     known = Set(["c1", "c2", "c3"])
+    # findMUS emits one field per line, with no space before the colon.
     report = """
     preamble
     %%%mzn-json-start
-    { "expression_name" : "c1" },
-    { "expression_name" : "c2" }
+    { "expression_name": "c1" },
+    { "expression_name": "c2" }
     %%%mzn-json-end
     """
     @test MiniZinc._parse_findmus_tokens(report, known) == Set(["c1", "c2"])
+    # A compacted block (several fields on one line) must still yield every
+    # member, not just the first.
+    compact = "%%%mzn-json-start\n{\"expression_name\": \"c1\", \"x\": 0, \"expression_name\": \"c2\"}\n%%%mzn-json-end\n"
+    @test MiniZinc._parse_findmus_tokens(compact, known) == Set(["c1", "c2"])
     # An `expression_name` outside the JSON block is ignored.
     @test isempty(
-        MiniZinc._parse_findmus_tokens("\"expression_name\" : \"c1\"", known),
+        MiniZinc._parse_findmus_tokens("\"expression_name\": \"c1\"", known),
     )
     # Tokens we did not emit are ignored even inside the block.
-    foreign = "%%%mzn-json-start\n{ \"expression_name\" : \"other\" }\n%%%mzn-json-end\n"
+    foreign = "%%%mzn-json-start\n{\"expression_name\": \"other\"}\n%%%mzn-json-end\n"
     @test isempty(MiniZinc._parse_findmus_tokens(foreign, known))
     # No block markers -> nothing found.
     @test isempty(MiniZinc._parse_findmus_tokens("no markers here", known))
+    return
+end
+
+# The findMUS command is not exercised by CI without findMUS installed, so lock
+# its flags here. Each is load-bearing and verified against findMUS v0.7.0.
+function test_findmus_command()
+    cmd = MiniZinc._findmus_cmd(
+        "minizinc",
+        "/x/findmus.msc",
+        "/x/model.mzn",
+        60_000,
+        30_000,
+    )
+    args = cmd.exec
+    for flag in (
+        "--named-only",
+        "-g",
+        "--soft-defines",
+        "--paramset",
+        "mzn",
+        "--output-json",
+        "--no-leftover",
+        "org.chuffed.chuffed",
+    )
+        @test flag in args
+    end
+    @test args[findfirst(==("-n"), args)+1] == "1"
+    @test args[findfirst(==("-t"), args)+1] == "60000"
+    @test args[findfirst(==("--subsolver-timelimit"), args)+1] == "30000"
     return
 end
 
@@ -2132,7 +2200,7 @@ function test_classify_conflict()
     F, S = MOI.ScalarAffineFunction{Int}, MOI.LessThan{Int}
     ci(i) = MOI.ConstraintIndex{F,S}(i)
     tokens = Dict{MOI.ConstraintIndex,String}(ci(1) => "c1", ci(2) => "c2")
-    mus = "%%%mzn-json-start\n{ \"expression_name\" : \"c2\" }\n%%%mzn-json-end\n"
+    mus = "%%%mzn-json-start\n{ \"expression_name\": \"c2\" }\n%%%mzn-json-end\n"
     # A reported MUS -> CONFLICT_FOUND with exactly its members, trusted even
     # when the process also reports a non-zero exit.
     status, conflict = MiniZinc._classify_conflict(
@@ -2171,6 +2239,17 @@ function test_classify_conflict()
             tokens,
         ),
     )
+    # An empty token table (a model with no annotatable constraints, e.g. only
+    # variable bounds, which fold into declarations) can never yield
+    # CONFLICT_FOUND, whatever the report contains.
+    status, conflict = MiniZinc._classify_conflict(
+        mus,
+        "",
+        nothing,
+        Dict{MOI.ConstraintIndex,String}(),
+    )
+    @test status == MOI.NO_CONFLICT_FOUND
+    @test isempty(conflict)
     return
 end
 


### PR DESCRIPTION
This adds MathOptInterface conflict (IIS) support to the MiniZinc `Optimizer`, implementing `MOI.compute_conflict!`, `MOI.ConflictStatus`, and `MOI.ConstraintConflictStatus`.

### Approach

The core `minizinc` driver exposes no MUS / unsat-core / assumption interface, so the conflict is computed with [findMUS](https://gitlab.com/minizinc/FindMUS), a Minimal Unsatisfiable Subset tool that runs as a MiniZinc pseudo-solver (`minizinc --solver findMUS`).

- `write.jl` gains an opt-in mode (a flag in `model.ext`) that stamps each emitted constraint with a unique string annotation, e.g. `constraint (<body>) :: "c3";`. The annotation is spliced into the single `constraint …;` statement each `_write_constraint` method already emits, so the ~15 overloads are untouched. A runtime check (not `@assert`, which may be disabled at higher optimization levels) enforces the one-statement-per-overload invariant the splice relies on.
- findMUS echoes that annotation back as the constraint's `expression_name` in its `--output-json` report; `compute_conflict.jl` parses the report and maps each token back to the originating `ConstraintIndex`. `--named-only` scopes the search to the annotated constraints; `-g --soft-defines` keep bound/functional constraints from being absorbed into variable domains; `--no-leftover` guarantees any reported MUS is minimal.

### Conflict status semantics

- `CONFLICT_FOUND` — a minimal conflict was isolated; its members read `IN_CONFLICT`.
- `NO_CONFLICT_EXISTS` — findMUS proved the model satisfiable (its initial full-model SAT check succeeds before any MUS search), so no conflict exists. This is the result `MOI.Test.test_solve_conflict_feasible` expects.
- `NO_CONFLICT_FOUND` — the model was not proven feasible, but no conflict could be attributed to its constraints: the conflict lies only in unnamed/background constraints, or could not be isolated within the time limit. This does **not** assert feasibility.

A genuine findMUS failure (could not run, crashed, or exited non-zero with no recognised outcome) throws an `ErrorException` whose message carries the findMUS reason and captured output, so a caller can surface it.

### Locating findMUS

findMUS is not part of the standard MiniZinc distribution. It is supplied by the [`FindMUS_jll`](https://github.com/JuliaBinaryWrappers/FindMUS_jll.jl) package (Yggdrasil recipe JuliaPackaging/Yggdrasil#13837, now registered in General), which this PR adds as a dependency, so there is no setup step: `compute_conflict!` locates the solver via `FindMUS_jll.findmus_msc`. The bundled `findmus.msc` resolves the findMUS executable through a path relative to the JLL artifact, so it stays valid from any depot location. (`JULIA_FINDMUS_MSC` still overrides the bundled config; it is used only by the failure test, which points it at a config whose binary is missing.)

Because `FindMUS_jll@0.7.0` is ABI-locked to `MiniZinc_jll@2.9.5`, `[compat]` pins `MiniZinc_jll = "=2.9.5"`. The earlier `2.7.6` / `2.8.5` / `2.9.3` entries are removed: once `FindMUS_jll` is a dependency they can no longer be selected, so listing them only misrepresented the supported set.

### Notes for reviewers

- **MOI.Test conflict coverage.** `test_moi_conflict_tests` runs MOI's own `test_solve_conflict_*` suite against the optimizer. `test_solve_conflict_two_affine` and `test_solve_conflict_feasible` pass; the remainder are excluded with documented reasons. `bound_bound`, `invalid_interval`, `affine_affine`, `EqualTo`, and `NOT_IN_CONFLICT` each assert that a variable bound (e.g. `x >= 0`) is `IN_CONFLICT`, and `zeroone`/`zeroone_2` that a `ZeroOne` integrality is — but MiniZinc folds variable bounds and integrality into the variable declaration, so they have no constraint line to annotate and surface as `NO_CONFLICT_FOUND`. The annotation logic, report parsing, and outcome classification are additionally unit-tested without findMUS present.
- **`ConflictCount` and query validation.** `ConflictCount` returns 1 when a conflict was found, else 0 (findMUS reports a single minimal conflict). `ConstraintConflictStatus` queries validate the conflict index (`check_conflict_index_bounds`, throwing `ConflictIndexBoundsError`) and the constraint (`throw_if_not_valid`, throwing `InvalidIndex`), matching the MockOptimizer getter contract. These conflict-index APIs were introduced in MathOptInterface 1.43, so `[compat]` requires `MathOptInterface = "1.43"`.
- **No `MAYBE_IN_CONFLICT`.** `--no-leftover` yields a guaranteed-minimal set, so every constraint is definitively in or out — there is no partial-attribution case to represent.
- **Pre-compute guard.** Querying `ConstraintConflictStatus` before `compute_conflict!` throws `MOI.GetAttributeNotAllowed` (the typed, current MOI idiom, as `HiGHS.jl` uses for `ConstraintBasisStatus`), rather than an untyped error.
- **CI matrix.** The Julia 1.10 floor is tested on macOS. The ubuntu + Julia 1.10 job is excluded (a matrix `exclude`) because `MiniZinc_jll@2.9.5` bundles `HiGHS_jll@1.13.1`, whose Linux binary segfaults under Julia 1.10 in the pre-existing `test_highs_feasibility` test (reproducible on ubuntu + 1.10; green on macOS + 1.10 and ubuntu + Julia 1.11). That crash is an upstream binary bug unrelated to this PR.
- The classification logic is a pure function (`_classify_conflict`), and the findMUS command line is built by a pure helper (`_findmus_cmd`), so both are unit-tested with canned reports / argument assertions without needing findMUS present.

New tests added; existing tests unchanged. README documents the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
