### PR TITLE
Tee output for user logging

### DIFF
--- a/src/MiniZinc.jl
+++ b/src/MiniZinc.jl
@@ -135,6 +135,7 @@ const _PREDICATE_NAMES = Set(["alldifferent"])
 
 MOI.get(::Model, ::MOI.ListOfSupportedNonlinearOperators) = _SUPPORTED_OPS
 
+include("tee.jl")
 include("write.jl")
 include("optimize.jl")
 include("compute_conflict.jl")

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -103,7 +103,18 @@ function _run_minizinc(dest::Optimizer)
             if dest.options["num_solutions"] !== nothing
                 cmd = `$cmd --num-solutions $(dest.options["num_solutions"])`
             end
-            return run(pipeline(cmd, stdout = _stdout, stderr = _stderr))
+            # use `open(...)` blocks so that it always flushes, even on errors
+            open(_stdout, "w") do out
+                open(_stderr, "w") do err
+                    return run(
+                        pipeline(
+                            cmd,
+                            stdout = dest.silent ? out : _Tee(out, stdout),
+                            stderr = dest.silent ? err : _Tee(err, stderr),
+                        ),
+                    )
+                end
+            end
         end
     catch
         status = "=====ERROR=====\n"

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -54,7 +54,7 @@ mutable struct Optimizer{T} <: MOI.AbstractOptimizer
             zero(T),
             primal_solutions,
             options,
-            false,
+            true,
             nothing,
             NaN,
             MOI.COMPUTE_CONFLICT_NOT_CALLED,

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -31,6 +31,7 @@ mutable struct Optimizer{T} <: MOI.AbstractOptimizer
     primal_objective::T
     primal_solutions::Vector{Dict{MOI.VariableIndex,T}}
     options::Dict{String,Any}
+    silent::Bool
     time_limit_sec::Union{Nothing,Float64}
     solve_time_sec::Float64
     # Conflict (IIS) state, populated by `compute_conflict!`. `conflict_status`
@@ -53,6 +54,7 @@ mutable struct Optimizer{T} <: MOI.AbstractOptimizer
             zero(T),
             primal_solutions,
             options,
+            false,
             nothing,
             NaN,
             MOI.COMPUTE_CONFLICT_NOT_CALLED,
@@ -182,6 +184,15 @@ function MOI.set(
         throw(MOI.SetAttributeNotAllowed(attr, msg))
     end
     model.options["num_solutions"] = value
+    return
+end
+
+MOI.supports(::Optimizer, ::MOI.Silent) = true
+
+MOI.get(model::Optimizer, ::MOI.Silent) = model.silent
+
+function MOI.set(model::Optimizer, ::MOI.Silent, value::Bool)
+    model.silent = value
     return
 end
 

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -95,7 +95,7 @@ function _run_minizinc(dest::Optimizer)
     _stderr = joinpath(dir, "_stderr.txt")
     try
         _minizinc_exe() do exe
-            cmd = `$(exe) --solver $(dest.solver) --output-objective -o $(output) $(filename)`
+            cmd = `$(exe) -v --solver $(dest.solver) --output-objective -o $(output) $(filename)`
             if dest.time_limit_sec !== nothing
                 limit = round(Int, 1_000 * dest.time_limit_sec::Float64)
                 cmd = `$cmd --time-limit $limit`

--- a/src/tee.jl
+++ b/src/tee.jl
@@ -1,0 +1,33 @@
+# Copyright (c) 2022 MiniZinc.jl contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+# An `IO` that mirrors everything written to it into two sinks. Used to stream
+# solver output live to the user's terminal while still capturing it to the
+# files that the result-parsing and error paths read. `run(pipeline(...))`
+# accepts any writable `IO` as a redirect target: Base copies the child's
+# output through `unsafe_write`, and `write(::IO, ::UInt8)` is the fallback
+# that generic `print`/`write` calls reduce to.
+struct _Tee{A<:IO,B<:IO} <: IO
+    a::A
+    b::B
+end
+
+function Base.write(t::_Tee, byte::UInt8)
+    write(t.a, byte)
+    return write(t.b, byte)
+end
+
+function Base.unsafe_write(t::_Tee, p::Ptr{UInt8}, n::UInt)
+    unsafe_write(t.a, p, n)
+    return unsafe_write(t.b, p, n)
+end
+
+function Base.flush(t::_Tee)
+    flush(t.a)
+    flush(t.b)
+    return
+end
+
+Base.iswritable(::_Tee) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,38 @@ function _test_file_contents(filename, args...)
     return
 end
 
+function test_tee_write()
+    a, b = IOBuffer(), IOBuffer()
+    tee = MiniZinc._Tee(a, b)
+    @test iswritable(tee)
+    write(tee, UInt8('x'))
+    print(tee, " hello ")
+    write(tee, "world ")
+    print(tee, 42)
+    # A payload larger than one pipe buffer, to cover the chunked
+    # `unsafe_write` path.
+    payload = "y"^100_000
+    write(tee, payload)
+    flush(tee)
+    for io in (a, b)
+        @test String(take!(io)) == "x hello world 42" * payload
+    end
+    return
+end
+
+function test_tee_subprocess()
+    # `_Tee` must be usable as a `run(pipeline(...))` redirect target, with the
+    # process's output landing in both sinks by the time `run` returns.
+    file = joinpath(mktempdir(), "stdout.txt")
+    mirror = IOBuffer()
+    open(file, "w") do io
+        return run(pipeline(`echo hello`; stdout = MiniZinc._Tee(io, mirror)))
+    end
+    @test read(file, String) == "hello\n"
+    @test String(take!(mirror)) == "hello\n"
+    return
+end
+
 function test_write_bool_model()
     model = MiniZinc.Model{Bool}()
     x = MOI.add_variable(model)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1639,6 +1639,45 @@ function test_highs_optimization_time_limit()
     return
 end
 
+function test_highs_optimization_silent()
+    model = MOI.Utilities.Model{Float64}()
+    x, _ = MOI.add_constrained_variable(model, MOI.Integer())
+    MOI.add_constraint(model, x, MOI.Interval(1.0, 10.0))
+    MOI.set(model, MOI.ObjectiveFunction{typeof(x)}(), x)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    solver = MiniZinc.Optimizer{Float64}("highs")
+    # set/unset silent
+    @test MOI.supports(solver, MOI.Silent())
+    MOI.set(solver, MOI.Silent(), true)
+    @test MOI.get(solver, MOI.Silent()) == true
+    MOI.set(solver, MOI.Silent(), false)
+    @test MOI.get(solver, MOI.Silent()) == false
+    mktempdir() do dir
+        # check that we logged something
+        loud_log = joinpath(dir, "loud.log")
+        open(loud_log, "w") do logfile
+            redirect_stdout(logfile) do
+                return redirect_stderr(logfile) do
+                    return MOI.optimize!(solver, model)
+                end
+            end
+        end
+        @test occursin("MiniZinc", read(loud_log, String))
+        # back to silent
+        MOI.set(solver, MOI.Silent(), true)
+        silent_log = joinpath(dir, "silent.log")
+        open(silent_log, "w") do logfile
+            redirect_stdout(logfile) do
+                return redirect_stderr(logfile) do
+                    return MOI.optimize!(solver, model)
+                end
+            end
+        end
+        @test isempty(read(silent_log, String))
+    end
+    return
+end
+
 function test_version_number()
     solver = MiniZinc.Optimizer{Float64}("highs")
     version = MOI.get(solver, MOI.SolverVersion())


### PR DESCRIPTION
I wrote this PR so users could follow minizinc (and the solvers) logs.  Now that this is written, I am not sure those logs are all that helpful, but thought I would log this anyways.

- Claude helped write the tee stream part, I havent done this before but it looks okay to me
- Added `MOI.Silent`, but this defaults to `true`
- If not silent, we still call minizinc, but this time stdout/stderr get redirected **both** to file (needed for solution getting) and to the terminal for the user
- Added `-v` flag to minizinc call. There are a [few logging options available](https://docs.minizinc.dev/en/stable/command_line.html). This one has the most output and includes the lower-level solver outputs, but is a lot of output, which is why I defaulted `MOI.Silent` to true.

I'm not sure the broader implications of using a tee as the solution here. I guess an alternative could be an async tail-like command? Or maybe its possible to just capture the output instead of redirecting it from the beginning?

Any feedback appreciated, thanks in advance :)